### PR TITLE
feat(plugins): warn when plugin venv was built with a different Python

### DIFF
--- a/packages/deepctl-core/src/deepctl_core/plugin_env.py
+++ b/packages/deepctl-core/src/deepctl_core/plugin_env.py
@@ -96,6 +96,45 @@ def get_venv_python() -> str | None:
     return str(python) if python.exists() else None
 
 
+def get_venv_python_version() -> tuple[int, int] | None:
+    """Read the (major, minor) Python version that built the plugin venv.
+
+    Reads ``pyvenv.cfg`` from :data:`PLUGIN_VENV`. Both ``version`` (stdlib
+    ``python -m venv``) and ``version_info`` (uv-created venvs) are accepted.
+
+    Returns ``None`` when the venv doesn't exist, the cfg file is missing,
+    or the version line can't be parsed — callers should treat ``None`` as
+    "unknown" and skip ABI-mismatch checks rather than failing loudly.
+    """
+    if not PLUGIN_VENV.exists():
+        return None
+
+    cfg = PLUGIN_VENV / "pyvenv.cfg"
+    if not cfg.exists():
+        return None
+
+    try:
+        text = cfg.read_text()
+    except OSError:
+        return None
+
+    for line in text.splitlines():
+        key, sep, value = line.partition("=")
+        if not sep:
+            continue
+        if key.strip() not in ("version", "version_info"):
+            continue
+        parts = value.strip().split(".")
+        if len(parts) < 2:
+            continue
+        try:
+            return int(parts[0]), int(parts[1])
+        except ValueError:
+            continue
+
+    return None
+
+
 def get_venv_site_packages() -> Path | None:
     """Return the ``site-packages`` directory inside the plugin venv.
 

--- a/packages/deepctl-core/src/deepctl_core/plugin_manager.py
+++ b/packages/deepctl-core/src/deepctl_core/plugin_manager.py
@@ -12,7 +12,13 @@ from rich.console import Console
 from .base_command import BaseCommand
 from .base_group_command import BaseGroupCommand
 from .models import ErrorResult, PluginInfo
-from .plugin_env import PLUGIN_VENV, get_plugin_state, get_venv_site_packages
+from .output import print_warning
+from .plugin_env import (
+    PLUGIN_VENV,
+    get_plugin_state,
+    get_venv_python_version,
+    get_venv_site_packages,
+)
 from .timing import TimingContext
 
 console = Console()
@@ -139,6 +145,8 @@ class PluginManager:
         if site_packages is None:
             return
 
+        self._warn_if_plugin_venv_python_mismatch()
+
         site_packages_str = str(site_packages)
 
         # Append to sys.path so modules inside the plugin venv can be imported.
@@ -185,6 +193,36 @@ class PluginManager:
 
         except Exception as e:
             console.print(f"[red]Error loading plugins from plugin venv:[/red] {e}")
+
+    def _warn_if_plugin_venv_python_mismatch(self) -> None:
+        """Surface a one-line warning when the plugin venv's Python differs from ours.
+
+        Triggered when the underlying interpreter is bumped (e.g. ``brew upgrade
+        python@3.13`` rebuilding deepctl against a newer Python) without the user
+        recreating ``~/.deepctl/plugins/venv/``. Pure-Python plugins keep loading
+        via :data:`sys.path` bridging; only C-extension plugins fail to load,
+        and they fail with a confusing low-level ImportError. This warning gives
+        users a clear remediation before they hit that error.
+
+        Silent when the venv version can't be determined (no ``pyvenv.cfg``,
+        unparseable cfg, etc.) — there's no useful guidance to give.
+        """
+        venv_version = get_venv_python_version()
+        if venv_version is None:
+            return
+
+        running = (sys.version_info.major, sys.version_info.minor)
+        if venv_version == running:
+            return
+
+        venv_str = f"{venv_version[0]}.{venv_version[1]}"
+        running_str = f"{running[0]}.{running[1]}"
+        print_warning(
+            f"Plugin environment was built with Python {venv_str} but you're "
+            f"running Python {running_str}. C-extension plugins may fail to "
+            f"load. To rebuild:\n"
+            f"  rm -rf {PLUGIN_VENV} && deepctl plugin install <your-plugin>"
+        )
 
     def _create_click_command(self, command_instance: Any) -> click.Command:
         """Create a Click command from a BaseCommand instance.

--- a/packages/deepctl-core/tests/unit/test_plugin_env.py
+++ b/packages/deepctl-core/tests/unit/test_plugin_env.py
@@ -18,6 +18,7 @@ from deepctl_core.plugin_env import (
     find_system_python,
     get_plugin_state,
     get_venv_python,
+    get_venv_python_version,
     get_venv_site_packages,
     is_frozen,
     save_plugin_state,
@@ -191,6 +192,70 @@ class TestGetVenvSitePackages:
                 mock_sys.platform = "win32"
                 result = get_venv_site_packages()
                 assert result == sp
+
+
+class TestGetVenvPythonVersion:
+    """Test get_venv_python_version()."""
+
+    @pytest.mark.unit
+    def test_returns_none_when_venv_missing(self, tmp_path):
+        venv = tmp_path / "missing-venv"
+        with patch("deepctl_core.plugin_env.PLUGIN_VENV", venv):
+            assert get_venv_python_version() is None
+
+    @pytest.mark.unit
+    def test_returns_none_when_pyvenv_cfg_missing(self, tmp_path):
+        venv = tmp_path / "venv"
+        venv.mkdir()
+        with patch("deepctl_core.plugin_env.PLUGIN_VENV", venv):
+            assert get_venv_python_version() is None
+
+    @pytest.mark.unit
+    def test_parses_stdlib_version_key(self, tmp_path):
+        venv = tmp_path / "venv"
+        venv.mkdir()
+        (venv / "pyvenv.cfg").write_text(
+            "home = /usr/bin\n"
+            "include-system-site-packages = false\n"
+            "version = 3.13.7\n"
+        )
+        with patch("deepctl_core.plugin_env.PLUGIN_VENV", venv):
+            assert get_venv_python_version() == (3, 13)
+
+    @pytest.mark.unit
+    def test_parses_uv_version_info_key(self, tmp_path):
+        venv = tmp_path / "venv"
+        venv.mkdir()
+        (venv / "pyvenv.cfg").write_text(
+            "home = /Users/lukeocodes/.local/share/uv/python/cpython-3.12-macos\n"
+            "implementation = CPython\n"
+            "uv = 0.11.7\n"
+            "version_info = 3.12.4\n"
+        )
+        with patch("deepctl_core.plugin_env.PLUGIN_VENV", venv):
+            assert get_venv_python_version() == (3, 12)
+
+    @pytest.mark.unit
+    def test_returns_none_on_malformed_version(self, tmp_path):
+        venv = tmp_path / "venv"
+        venv.mkdir()
+        (venv / "pyvenv.cfg").write_text(
+            "home = /usr/bin\n"
+            "version = not-a-version\n"
+        )
+        with patch("deepctl_core.plugin_env.PLUGIN_VENV", venv):
+            assert get_venv_python_version() is None
+
+    @pytest.mark.unit
+    def test_returns_none_when_no_version_key(self, tmp_path):
+        venv = tmp_path / "venv"
+        venv.mkdir()
+        (venv / "pyvenv.cfg").write_text(
+            "home = /usr/bin\n"
+            "include-system-site-packages = false\n"
+        )
+        with patch("deepctl_core.plugin_env.PLUGIN_VENV", venv):
+            assert get_venv_python_version() is None
 
 
 class TestGetPluginState:

--- a/packages/deepctl-core/tests/unit/test_plugin_manager.py
+++ b/packages/deepctl-core/tests/unit/test_plugin_manager.py
@@ -516,3 +516,77 @@ class TestPluginManager:
                             )
                             # Should be in loaded_plugins
                             assert "venv-plugin" in plugin_manager.loaded_plugins
+
+    @pytest.mark.unit
+    def test_warn_if_plugin_venv_python_mismatch_silent_when_unknown(
+        self, plugin_manager
+    ):
+        """No warning when get_venv_python_version returns None."""
+        with patch(
+            "deepctl_core.plugin_manager.get_venv_python_version",
+            return_value=None,
+        ):
+            with patch("deepctl_core.plugin_manager.print_warning") as mock_warn:
+                plugin_manager._warn_if_plugin_venv_python_mismatch()
+                mock_warn.assert_not_called()
+
+    @pytest.mark.unit
+    def test_warn_if_plugin_venv_python_mismatch_silent_when_match(
+        self, plugin_manager
+    ):
+        """No warning when venv version matches running interpreter."""
+        with patch(
+            "deepctl_core.plugin_manager.get_venv_python_version",
+            return_value=(3, 13),
+        ):
+            with patch(
+                "deepctl_core.plugin_manager.sys.version_info",
+                Mock(major=3, minor=13),
+            ):
+                with patch(
+                    "deepctl_core.plugin_manager.print_warning"
+                ) as mock_warn:
+                    plugin_manager._warn_if_plugin_venv_python_mismatch()
+                    mock_warn.assert_not_called()
+
+    @pytest.mark.unit
+    def test_warn_if_plugin_venv_python_mismatch_warns_on_minor_diff(
+        self, plugin_manager
+    ):
+        """Warning fires when venv minor differs from running interpreter."""
+        with patch(
+            "deepctl_core.plugin_manager.get_venv_python_version",
+            return_value=(3, 12),
+        ):
+            with patch(
+                "deepctl_core.plugin_manager.sys.version_info",
+                Mock(major=3, minor=13),
+            ):
+                with patch(
+                    "deepctl_core.plugin_manager.print_warning"
+                ) as mock_warn:
+                    plugin_manager._warn_if_plugin_venv_python_mismatch()
+                    mock_warn.assert_called_once()
+                    msg = mock_warn.call_args[0][0]
+                    assert "3.12" in msg
+                    assert "3.13" in msg
+                    assert "rm -rf" in msg
+
+    @pytest.mark.unit
+    def test_warn_if_plugin_venv_python_mismatch_warns_on_major_diff(
+        self, plugin_manager
+    ):
+        """Warning fires when venv major differs (e.g. Python 4 someday)."""
+        with patch(
+            "deepctl_core.plugin_manager.get_venv_python_version",
+            return_value=(3, 13),
+        ):
+            with patch(
+                "deepctl_core.plugin_manager.sys.version_info",
+                Mock(major=4, minor=0),
+            ):
+                with patch(
+                    "deepctl_core.plugin_manager.print_warning"
+                ) as mock_warn:
+                    plugin_manager._warn_if_plugin_venv_python_mismatch()
+                    mock_warn.assert_called_once()


### PR DESCRIPTION
## Summary

Closes the last edge case in our \"Homebrew installs + plugins\" story. When `brew upgrade python@3.13` rebuilds deepctl against a newer underlying Python, the user's plugin venv at `~/.deepctl/plugins/venv/` keeps the *old* Python it was built with. C-extension plugins then fail to load with a confusing low-level `ImportError` and no breadcrumb to the fix.

This PR detects that mismatch and prints a one-line, actionable warning at plugin-load time:

```
⚠ Plugin environment was built with Python 3.12 but you're running Python 3.13.
  C-extension plugins may fail to load. To rebuild:
    rm -rf /Users/<you>/.deepctl/plugins/venv && deepctl plugin install <your-plugin>
```

Pure-Python plugins continue to load transparently via `sys.path` bridging — the warning fires *alongside* normal loading, not as a blocker.

## Why now

Companion to:
- [`deepgram/homebrew-tap#1`](https://github.com/deepgram/homebrew-tap/pull/1) — the new Homebrew formula
- [`deepgram/cli#42`](https://github.com/deepgram/cli/pull/42) — release-automation that keeps the formula fresh

The plugin system [already routes Homebrew installs through `IsolatedVenvStrategy`](https://github.com/deepgram/cli/blob/main/packages/deepctl-cmd-plugin/src/deepctl_cmd_plugin/strategies.py#L158-L185), so plugins survive the install path by design. The Python-version-bump scenario is the only remaining failure mode that's hard to diagnose from a user's perspective. Closing it now means we ship the Homebrew install path with a complete plugin story.

## What lands

| File | Change |
|---|---|
| `packages/deepctl-core/src/deepctl_core/plugin_env.py` | New `get_venv_python_version()` reads `pyvenv.cfg`, returns `(major, minor)` or `None` on missing/malformed cfg |
| `packages/deepctl-core/src/deepctl_core/plugin_manager.py` | New `_warn_if_plugin_venv_python_mismatch()` fires inside `_load_plugin_venv_entries`, before sys.path bridging |
| `packages/deepctl-core/tests/unit/test_plugin_env.py` | 6 new test cases for `get_venv_python_version` |
| `packages/deepctl-core/tests/unit/test_plugin_manager.py` | 4 new test cases for the warning logic |

## Design notes

- **`pyvenv.cfg` parsing handles both `version` (stdlib `python -m venv`) and `version_info` (uv-created venvs).** Both formats use `MAJOR.MINOR.PATCH...` semantics so splitting on `.` and taking `[0:2]` works for both.
- **`None` from `get_venv_python_version` means \"unknown, skip the check\"** — explicitly documented in the function's docstring and respected by `_warn_if_plugin_venv_python_mismatch`. Avoids noisy false-positive warnings when the cfg is missing on weird/legacy venvs.
- **Warning fires once per CLI invocation** (process-level), and only when a tracked plugin exists (`plugin venv exists` + `plugins.json` non-empty), so users without plugins never see it.
- **Comparison is at major.minor granularity** — patch-level differences (3.13.7 → 3.13.8) don't break ABI compatibility, so they don't warrant a warning.

## Verification

| Check | Result |
|---|---|
| `pytest packages/deepctl-core/tests/unit/test_plugin_*.py -v` | **48 passed** (10 new, 38 existing) |
| `ruff check` (changed src files) | clean |
| `ruff format --check` (changed src files) | clean |
| `mypy --strict` (changed src files) | clean |
| Existing `_load_plugin_venv_entries` behavior | unchanged for users without plugins or with matching Python |

The 21 ruff warnings and 5 mypy errors visible in a wider check are all pre-existing in files this PR doesn't touch (`auth.py`, `deepctl_cmd_mcp`, `test_auth.py`, etc.) — out of scope per repo policy.

## Pre-existing comments / docstrings

A few docstrings in the new code were retained as Category 3 necessary:
- **`get_venv_python_version`** — public API in `deepctl_core`, documents the dual `version`/`version_info` key support and the `None` contract that `_warn_if_plugin_venv_python_mismatch` depends on
- **`_warn_if_plugin_venv_python_mismatch`** — documents *when* it fires (the Homebrew Python-bump scenario) and *why we warn instead of block* (so future \"robustness\" PRs don't break the pure-Python plugin case by raising/skipping)
- **Test class + method docstrings** — match the file's strong existing convention (every test has a docstring) and are surfaced in pytest `-v` output

Each describes a behavioral contract that the code alone can't communicate; removing them would predictably lead to wrong-direction refactors.

## Out of scope

This PR doesn't try to *automatically* recreate the plugin venv on mismatch. That would be a more invasive change with its own failure modes (what if the rebuild fails partway through? what about user-installed dev plugins via `--editable`?). The single-line warning with explicit remediation is a much smaller blast radius. If users frequently hit this, we can layer auto-recovery on top later.