### PR TITLE
docs: add Homebrew install path to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,15 @@ intelligence, and project management directly into your terminal. Aliases:
 
 ### Quick Install
 
-**macOS / Linux:**
+**macOS / Linux (Homebrew):**
+
+```bash
+brew install deepgram/tap/deepgram
+```
+
+Homebrew brings in `ffmpeg` and `portaudio` automatically — `dg listen --mic`, `dg debug probe`, and raw audio piping all work without further setup. To upgrade later: `brew upgrade deepgram`.
+
+**macOS / Linux (curl):**
 
 ```bash
 curl -fsSL https://deepgram.com/install.sh | sh

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ intelligence, and project management directly into your terminal. Aliases:
 **macOS / Linux (Homebrew):**
 
 ```bash
-brew install deepgram/tap/deepgram
+brew tap deepgram/tap
+brew install deepgram
 ```
 
 Homebrew brings in `ffmpeg` and `portaudio` automatically — `dg listen --mic`, `dg debug probe`, and raw audio piping all work without further setup. To upgrade later: `brew upgrade deepgram`.


### PR DESCRIPTION
## Summary

Adds Homebrew as the first option under **Quick Install** in the README:

```bash
brew install deepgram/tap/deepgram
```

Notes that Homebrew handles `ffmpeg` + `portaudio` automatically (covers `dg listen --mic`, `dg debug probe`, raw audio piping) and that future updates use `brew upgrade deepgram`.

## Why

Companion to [deepgram/homebrew-tap#1](https://github.com/deepgram/homebrew-tap/pull/1) (the formula) and [deepgram/cli#42](https://github.com/deepgram/cli/pull/42) (release-automation that keeps the formula fresh). Brew is now the canonical low-friction install path for Mac/Linux developers — sits at the top of "Quick Install" alongside the curl one-liner.

## Diff

`README.md`: 9 lines added, 1 modified. Just the Homebrew block under Quick Install — no other sections touched.

## Companion docs PR

[deepgram/deepgram-docs#834](https://github.com/deepgram/deepgram-docs/pull/834) — same content updated on the docs site's CLI install page (also fixes a stale `deepgram-cli` formula-name reference and removes a "if you have a custom tap configured" conditional).
