### PR TITLE
chore: unblock CI lint gate

### DIFF
--- a/packages/deepctl-cmd-debug-toolkit/src/deepctl_cmd_debug_toolkit/command.py
+++ b/packages/deepctl-cmd-debug-toolkit/src/deepctl_cmd_debug_toolkit/command.py
@@ -86,7 +86,9 @@ class ToolkitCommand(BaseGroupCommand):
 def _make_refresh_command() -> click.Command:
     """Static 'refresh' command — always available regardless of cache state."""
 
-    @click.command("refresh", help="Fetch the latest script list from deepgram/support-toolkit.")
+    @click.command(
+        "refresh", help="Fetch the latest script list from deepgram/support-toolkit."
+    )
     def _refresh() -> None:
         try:
             manifest = refresh_manifest(console)

--- a/packages/deepctl-cmd-debug-toolkit/src/deepctl_cmd_debug_toolkit/fetcher.py
+++ b/packages/deepctl-cmd-debug-toolkit/src/deepctl_cmd_debug_toolkit/fetcher.py
@@ -97,8 +97,7 @@ def refresh_manifest(console: Console) -> ToolkitManifest:
         console.print(f"[dim]Loading toolkit manifest from {local}[/dim]")
     else:
         console.print(
-            "[dim]Fetching toolkit manifest from "
-            f"github.com/{GITHUB_REPO}...[/dim]"
+            f"[dim]Fetching toolkit manifest from github.com/{GITHUB_REPO}...[/dim]"
         )
         _sha, content = _fetch_github_contents("toolkit.json")
 
@@ -135,9 +134,7 @@ def get_or_fetch_script(entry: ToolkitScript, console: Console) -> Path:
 
     # Download from GitHub with integrity verification.
     script_name = Path(entry.script).name
-    console.print(
-        f"[blue]Downloading[/blue] {script_name} from support-toolkit..."
-    )
+    console.print(f"[blue]Downloading[/blue] {script_name} from support-toolkit...")
     sha, content = _fetch_github_contents(entry.script)
 
     _SCRIPTS_CACHE.mkdir(parents=True, exist_ok=True)

--- a/packages/deepctl-cmd-mcp/src/deepctl_cmd_mcp/models.py
+++ b/packages/deepctl-cmd-mcp/src/deepctl_cmd_mcp/models.py
@@ -2,9 +2,7 @@
 
 from typing import Optional
 
-from deepgram_mcp import (
-    TransportType,  # noqa: F401 — re-exported for backwards compatibility
-)
+from deepgram_mcp import TransportType as TransportType
 from pydantic import BaseModel
 
 

--- a/packages/deepctl-core/src/deepctl_core/auth.py
+++ b/packages/deepctl-core/src/deepctl_core/auth.py
@@ -647,9 +647,13 @@ class AuthManager:
                 keyring.set_password(
                     KEYRING_SERVICE, f"refresh-token.{profile_name}", refresh_token
                 )
-                console.print("[green]✓[/green] Session stored securely in system keyring")
+                console.print(
+                    "[green]✓[/green] Session stored securely in system keyring"
+                )
             except Exception as e:
-                console.print(f"[yellow]Warning:[/yellow] Could not store in keyring: {e}")
+                console.print(
+                    f"[yellow]Warning:[/yellow] Could not store in keyring: {e}"
+                )
 
             # Store expiry timestamps and project ID in config (non-sensitive).
             profile = self.config.get_profile(profile_name)
@@ -664,11 +668,17 @@ class AuthManager:
             keyring_available = False
 
             try:
-                keyring.set_password(KEYRING_SERVICE, f"api-key.{profile_name}", api_key)
-                console.print("[green]✓[/green] API key stored securely in system keyring")
+                keyring.set_password(
+                    KEYRING_SERVICE, f"api-key.{profile_name}", api_key
+                )
+                console.print(
+                    "[green]✓[/green] API key stored securely in system keyring"
+                )
                 keyring_available = True
             except Exception as e:
-                console.print(f"[yellow]Warning:[/yellow] Could not store in keyring: {e}")
+                console.print(
+                    f"[yellow]Warning:[/yellow] Could not store in keyring: {e}"
+                )
                 console.print("API key will be stored in config file instead")
 
             self.config.create_profile(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,8 +132,16 @@ module = "deepctl_cmd_mcp.*"
 disable_error_code = ["call-arg", "no-untyped-call", "no-untyped-def", "untyped-decorator", "misc"]
 
 [[tool.mypy.overrides]]
-module = ["sounddevice", "sounddevice.*", "numpy", "numpy.*"]
-# Optional microphone dependencies — no type stubs available
+module = [
+    "sounddevice",
+    "sounddevice.*",
+    "numpy",
+    "numpy.*",
+    "deepgram_mcp",
+    "deepgram_mcp.*",
+]
+# Optional microphone dependencies (sounddevice, numpy) and the MCP SDK
+# (deepgram_mcp) ship without type stubs.
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Summary

Restores the CI Lint job (\`uv run ruff format --check && ruff check && mypy --strict\` against \`src/\` + \`packages/*/src\`) to green. Was failing on \`origin/main\` against pre-existing files, blocking every PR's lint gate until either fixed or admin-overridden.

## What it does

| Fix | Why it was broken |
|---|---|
| \`ruff format\` 3 files | \`debug-toolkit/{command,fetcher}.py\` + \`core/auth.py\` were committed unformatted (likely landed via [no-ci] paths or admin merges) |
| Add \`deepgram_mcp\` + \`deepgram_mcp.*\` to the existing \`ignore_missing_imports\` mypy override | The MCP SDK ships without type stubs, so \`import deepgram_mcp\` produced \`import-untyped\` errors. The existing override already covers \`sounddevice\`/\`numpy\`; adding \`deepgram_mcp\` to the same list is the minimal fix. |
| Switch one import in \`mcp/models.py\` to \`from X import Y as Y\` | The current \`from deepgram_mcp import TransportType\` + \`# noqa: F401\` produced an \`attr-defined\` error when re-exported via \`__init__.py\` under \`mypy --strict\`. The explicit \`as\` form is the standard way to mark a re-export for strict mypy and drops the now-redundant \`noqa\`. |

5 files, ~30 lines diff. **No logic changes** — pure config + format + import-statement shape.

## Verification

```
uv run ruff format --check src/ packages/*/src   # 112 files already formatted
uv run ruff check src/ packages/*/src            # All checks passed!
uv run mypy src/ packages/*/src                  # Success: no issues found in 112 source files
```

These are the exact commands [CI's Lint job](https://github.com/deepgram/cli/blob/main/.github/workflows/test.yml#L41-L65) runs.

## Context

These two fix commits originally landed on the [\`#42\` branch](https://github.com/deepgram/cli/pull/42) while it was open, but #42 was admin-merged before the fix commits could be picked up. They got stranded on the deleted branch. This PR brings them back as a single small chore so future PRs aren't blocked.