### PR TITLE
feat(deepctl-core): use dg alias in plugin venv ABI mismatch warning

### DIFF
--- a/.github/.release-please-manifest.json
+++ b/.github/.release-please-manifest.json
@@ -12,6 +12,7 @@
   "packages/deepctl-cmd-debug-browser": "0.1.11",
   "packages/deepctl-cmd-debug-network": "0.1.11",
   "packages/deepctl-cmd-debug-probe": "0.0.2",
+  "packages/deepctl-cmd-debug-toolkit": "0.0.0",
   "packages/deepctl-cmd-ffprobe": "0.0.2",
   "packages/deepctl-cmd-mcp": "0.1.12",
   "packages/deepctl-cmd-update": "0.2.4",

--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -77,6 +77,11 @@
       "include-component-in-tag": true,
       "make-latest": false
     },
+    "packages/deepctl-cmd-debug-toolkit": {
+      "component": "deepctl-cmd-debug-toolkit",
+      "include-component-in-tag": true,
+      "make-latest": false
+    },
     "packages/deepctl-cmd-ffprobe": {
       "component": "deepctl-cmd-ffprobe",
       "include-component-in-tag": true,

--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ cli/
 │   ├── deepctl-cmd-debug-browser/    # Browser debug subcommand for deepctl
 │   ├── deepctl-cmd-debug-network/    # Network debug subcommand for deepctl
 │   ├── deepctl-cmd-debug-probe/      # Debug probe subcommand for deepctl — live ffprobe analysis during streaming
+│   ├── deepctl-cmd-debug-toolkit/    # Toolkit subcommand for dg debug — runs field support scripts from deepgram/support-toolkit
 │   ├── deepctl-cmd-ffprobe/          # FFprobe configuration command for deepctl
 │   ├── deepctl-cmd-init/             # Init command for deepctl — scaffold Deepgram starter apps
 │   ├── deepctl-cmd-keys/             # API keys management command for deepctl
@@ -382,6 +383,7 @@ cli/
 | `deepctl debug browser` | Browser debug subcommand for deepctl |
 | `deepctl debug network` | Network debug subcommand for deepctl |
 | `deepctl debug probe` | Debug probe subcommand for deepctl — live ffprobe analysis during streaming |
+| `deepctl debug toolkit` | Toolkit subcommand for dg debug — runs field support scripts from deepgram/support-toolkit |
 | `deepctl debug` | Debug command group for deepctl |
 | `deepctl ffprobe` | FFprobe configuration command for deepctl |
 | `deepctl init` | Init command for deepctl — scaffold Deepgram starter apps |
@@ -418,6 +420,7 @@ cli/
 | [`deepctl-cmd-debug-browser`](packages/deepctl-cmd-debug-browser) | Browser debug subcommand for deepctl |
 | [`deepctl-cmd-debug-network`](packages/deepctl-cmd-debug-network) | Network debug subcommand for deepctl |
 | [`deepctl-cmd-debug-probe`](packages/deepctl-cmd-debug-probe) | Debug probe subcommand for deepctl — live ffprobe analysis during streaming |
+| [`deepctl-cmd-debug-toolkit`](packages/deepctl-cmd-debug-toolkit) | Toolkit subcommand for dg debug — runs field support scripts from deepgram/support-toolkit |
 | [`deepctl-cmd-ffprobe`](packages/deepctl-cmd-ffprobe) | FFprobe configuration command for deepctl |
 | [`deepctl-cmd-init`](packages/deepctl-cmd-init) | Init command for deepctl — scaffold Deepgram starter apps |
 | [`deepctl-cmd-keys`](packages/deepctl-cmd-keys) | API keys management command for deepctl |

--- a/packages/deepctl-cmd-debug-toolkit/README.md
+++ b/packages/deepctl-cmd-debug-toolkit/README.md
@@ -1,8 +1,10 @@
-# deepctl-cmd-listen
+# deepctl-cmd-debug-toolkit
 
 > Part of [deepctl](https://github.com/deepgram/cli) — Official Deepgram CLI
 
-Listen (live speech-to-text) command for deepctl
+Toolkit subcommand for dg debug — runs field support scripts from deepgram/support-toolkit
+
+This is a subcommand of `deepctl debug`.
 
 ## Installation
 
@@ -29,17 +31,15 @@ pipx run deepctl --help
 
 | Command | Entry Point |
 |---------|-------------|
-| `deepctl listen` | `deepctl_cmd_listen.command:ListenCommand` |
+| `deepctl debug toolkit` | `deepctl_cmd_debug_toolkit.command:ToolkitCommand` |
 
 ## Dependencies
 
-- `click>=8.0.0`
-- `rich>=13.0.0`
-- `pydantic>=2.0.0`
-- `websockets>=11.0`
-- `deepgram-captions>=2.0.0`
-- `sounddevice>=0.4.6`
-- `numpy>=1.24.0`
+- `httpx>=0.27.0`
+- `pydantic>=2.10.1`
+- `platformdirs>=4.0.0`
+- `rich>=13.9.4`
+- `click>=8.1.7`
 
 ## License
 

--- a/packages/deepctl-cmd-mcp/README.md
+++ b/packages/deepctl-cmd-mcp/README.md
@@ -140,12 +140,10 @@ deepctl mcp --transport sse --port 8000
 
 ## Dependencies
 
-- `mcp>=1.0.0`
+- `deepgram-mcp>=0.1.0`
 - `rich>=13.9.4`
 - `click>=8.1.7`
 - `pydantic>=2.10.1`
-- `uvicorn>=0.30.0`
-- `starlette>=0.37.0`
 
 ## License
 

--- a/packages/deepctl-core/src/deepctl_core/plugin_manager.py
+++ b/packages/deepctl-core/src/deepctl_core/plugin_manager.py
@@ -221,7 +221,7 @@ class PluginManager:
             f"Plugin environment was built with Python {venv_str} but you're "
             f"running Python {running_str}. C-extension plugins may fail to "
             f"load. To rebuild:\n"
-            f"  rm -rf {PLUGIN_VENV} && deepctl plugin install <your-plugin>"
+            f"  rm -rf {PLUGIN_VENV} && dg plugin install <your-plugin>"
         )
 
     def _create_click_command(self, command_instance: Any) -> click.Command:


### PR DESCRIPTION
## Summary

Two release-infrastructure fixes that need to land before [#46](https://github.com/deepgram/cli/pull/46) (release-please's `chore: release main`) is merged. Without this, `pip install deepctl==0.2.19` will **fail to resolve dependencies** for every user.

## What's broken

### 🔴 Install-blocker: `deepctl-cmd-debug-toolkit` is a phantom package

The toolkit subcommand was added in [`768f34f`](https://github.com/deepgram/cli/commit/768f34f485a499a2433596094bc5c7bada416361) (`feat(debug): add toolkit subcommand for deepgram/support-toolkit scripts`). The commit:

- ✅ Created `packages/deepctl-cmd-debug-toolkit/` with `pyproject.toml`, `src/`, etc.
- ✅ Added `deepctl-cmd-debug-toolkit>=0.0.1` to the umbrella `pyproject.toml` dependencies
- ✅ Added `[tool.uv.sources]` workspace mapping
- ❌ **Did not register the package in [`release-please-config.json`](https://github.com/deepgram/cli/blob/main/.github/release-please-config.json)**
- ❌ **Did not register the package in [`.release-please-manifest.json`](https://github.com/deepgram/cli/blob/main/.github/.release-please-manifest.json)**

Result: the package has never been built or published. `pip install deepctl-cmd-debug-toolkit` returns `Not Found` on PyPI today. When `deepctl 0.2.19` publishes with `deepctl-cmd-debug-toolkit>=0.0.1` in its dependency list, pip will try to resolve that and fail with a missing-distribution error.

[AGENTS.md step 6](https://github.com/deepgram/cli/blob/main/AGENTS.md#6-wire-into-the-workspace) calls out exactly this set of files as the workspace integration checklist for new packages — it just wasn't followed.

### 🟡 deepctl-core's plugin warning never reaches PyPI users

[`fb22d8a`](https://github.com/deepgram/cli/commit/fb22d8acace66e5c346f3de1e7d0ee0d87236577) (the squash merge of #42) added `_warn_if_plugin_venv_python_mismatch()` to `deepctl-core`'s `PluginManager`. But its squash-merge body included markdown tables and `## Summary` / `## What lands` headings, and `conventional-commits-parser` choked on it. The release-please run logs show:

```
❯ commit could not be parsed: fb22d8acace66e5c346f3de1e7d0ee0d87236577 feat(homebrew): homebrew tap support (#42)
```

release-please skipped the commit entirely. So deepctl-core stayed at **0.2.8** in the manifest, no bump, no PyPI release. The umbrella `deepctl 0.2.19` will publish with `deepctl-core>=0.1.10` which pip resolves to PyPI's 0.2.8 — **the version before the plugin warning was added**. The warning code is on `main` but no PyPI user gets it.

## Fixes in this PR

1. **Register `deepctl-cmd-debug-toolkit` with release-please.**
   - `.github/release-please-config.json` — add the package block (matches the convention every other sub-package uses)
   - `.github/.release-please-manifest.json` — add `\"packages/deepctl-cmd-debug-toolkit\": \"0.0.0\"` so release-please's first release bumps it to `0.0.1` (matches `pyproject.toml`)

2. **Trigger deepctl-core release with a parseable conventional commit.**

   Tweaks the plugin warning's remediation hint from `deepctl plugin install` to `dg plugin install` — the canonical user-facing alias used everywhere else in user messages and docs. Small real improvement. The squash-merge title `feat(deepctl-core): ...` parses cleanly and gives release-please a path-attributable feat on `packages/deepctl-core/*` to detect.

3. **Regenerate stale READMEs.**

   `scripts/generate_readmes.py --check` flagged 3 stale READMEs on `main` (root, `deepctl-cmd-listen`, `deepctl-cmd-mcp`) plus the missing `deepctl-cmd-debug-toolkit/README.md`. All four regenerated.

## After this merges

release-please will recompute and PR #46's body will look like:

```
<details><summary>0.2.19</summary>          # deepctl root
<details><summary>deepctl-cmd-debug-toolkit: 0.0.1</summary>   # NEW — fixes the install
<details><summary>deepctl-core: 0.2.9</summary>                # NEW — ships the plugin warning
```

Merging #46 then publishes all three to PyPI in one release event, and `pip install deepctl==0.2.19` resolves end-to-end.

## Verification

- `ruff format --check src/ packages/*/src` — 112 files already formatted
- `ruff check src/ packages/*/src` — clean
- `mypy --strict src/ packages/*/src` — clean (112 source files)
- `python scripts/generate_readmes.py --check` — all current
- 4 plugin-warning tests still pass (test message regex doesn't depend on `deepctl` vs `dg`)

## Pre-existing comments / docstrings

A couple of necessary comments still in this PR were retained per project convention:
- `_warn_if_plugin_venv_python_mismatch` docstring — Category 3, documents the *when* (Homebrew Python upgrade scenario), the *why-warn-instead-of-block* contract, and *None semantics*. Same justification as in #42.
- The text change is one character (`deepctl` → `dg`) and a minor improvement, not a behavioral change.