### PR TITLE
fix(brew): add rust + pkgconf as build-time deps in formula template

### DIFF
--- a/scripts/templates/deepgram.rb.template
+++ b/scripts/templates/deepgram.rb.template
@@ -12,6 +12,13 @@ class Deepgram < Formula
   sha256 "{{TARBALL_SHA256}}"
   license "MIT"
 
+  # Build-time deps for the `cryptography` and `pydantic_core` resources,
+  # which compile Rust extensions via `maturin`. Language::Python::Virtualenv
+  # defaults to --no-binary :all: so precompiled wheels are bypassed and the
+  # Rust toolchain has to be available during install.
+  depends_on "pkgconf" => :build
+  depends_on "rust" => :build
+
   # Used by `dg debug probe`, `dg ffprobe`, and raw-audio streaming flows
   # (e.g. `ffmpeg ... | dg listen --encoding linear16`).
   depends_on "ffmpeg"


### PR DESCRIPTION
## Summary

Companion to [the live-formula fix in deepgram/homebrew-tap](https://github.com/deepgram/homebrew-tap/pulls?q=is%3Apr+head%3Afix%2Frust-build-dep). Adds the same two build-time deps to the formula template here, so the next root \`v*\` release's auto-bump preserves the fix instead of regressing.

## What's broken

\`brew install deepgram/tap/deepgram\` is currently failing for every user during the \`cryptography\` and \`pydantic_core\` source builds. Both packages compile Rust extensions via \`maturin\`, and Homebrew's \`Language::Python::Virtualenv\` defaults to \`--no-binary :all:\` (forces source builds for security/reproducibility), so the precompiled PyPI wheels are bypassed and the Rust toolchain has to be available during the build.

The companion tap PR fixes the live formula. **Without this template change**, the next time \`scripts/bump_brew_formula.py\` regenerates the formula (i.e. on the next deepctl release), it would wipe the \`depends_on \"rust\"\` lines and re-break every install.

## Fix

Two new lines in \`scripts/templates/deepgram.rb.template\`:

```ruby
depends_on \"pkgconf\" => :build
depends_on \"rust\" => :build
```

Matches the exact pattern \`homebrew-core\`'s [Aider](https://github.com/Homebrew/homebrew-core/blob/main/Formula/a/aider.rb#L24-L26) uses (Aider is the closest precedent — same \`Language::Python::Virtualenv\` pattern, same \`pydantic-core\` resource). Several other homebrew-core formulas (ansible, azure-cli, aws-elasticbeanstalk, etc.) use the same fix.

Both deps are \`=> :build\` — build-time only, not runtime. No install bloat for end users.

## Verification

```
$ python scripts/bump_brew_formula.py --version 0.2.18 --dry-run | grep depends_on | head -10
  depends_on \"pkgconf\" => :build
  depends_on \"rust\" => :build
  depends_on \"ffmpeg\"
  depends_on \"portaudio\"
  depends_on \"python@3.13\"
```

The dry-run output now includes both build deps in the right alphabetical position (build deps before runtime deps, alphabetical within each section per \`brew style\`).

The full diff against the live tap formula is larger than just these two lines because PyPI churn since the original generation has bumped several transitive dep versions (deepctl-core 0.2.8 → 0.2.9 with the plugin warning shipped in v0.2.19, listen 0.0.9 → 0.0.10, mcp 0.1.12 → 0.1.13, typer 0.25.0 → 0.25.1, plus a new deepgram-mcp resource). All of those will land naturally on the next auto-bump and are unrelated to this fix.

## Pre-existing comments / docstrings

The new comment block above \`depends_on \"pkgconf\"\` is **necessary** — without it, a future \"lean dependencies\" refactor would correctly think \"there's no Rust code in this Python project, why is rust here?\" and remove the lines. Same silent-breakage failure mode as the auto-generated banner. Matches every other \`depends_on\` in the template which already has rationale comments.