### PR TITLE
ci: remove workflow_dispatch from web-production

### DIFF
--- a/.github/workflows/web-production.yml
+++ b/.github/workflows/web-production.yml
@@ -5,8 +5,13 @@ on:
   # Using workflow_call avoids the GitHub Actions limitation where
   # GITHUB_TOKEN-created releases do not trigger release: published
   # in other workflows.
+  #
+  # workflow_dispatch is intentionally omitted: deploying main outside
+  # the release pipeline can ship a landing page that advertises a
+  # version not yet published to PyPI (the cli.deepgram.com vs PyPI
+  # skew that broke installs in May 2026). Production deploys must be
+  # gated on a real root v* tag.
   workflow_call:
-  workflow_dispatch:
 
 # Only one production deploy at a time; never cancel in-progress
 concurrency:


### PR DESCRIPTION
## Summary

Removes the `workflow_dispatch` trigger from `web-production.yml` so manual deploys can no longer fire from the GitHub Actions UI.

## Why

I triggered a manual `workflow_dispatch` on this workflow today to push a doc-only fix that wouldn't have shipped via release-please (`docs:` doesn't bump). That deployed `main` HEAD, which already contained an in-flight version reference (`0.2.20`) from a merged release-please PR that hadn't actually shipped to PyPI yet. Result: cli.deepgram.com advertised a version users can't `pip install`. That should never have happened.

Production deploys need to be gated on a real root `v*` tag so the landing page never references a version PyPI doesn't have. The `workflow_call` path from `release.yml` already provides that — it fires AFTER `publish` completes and only on root tags.

## What changes

- `.github/workflows/web-production.yml`: drop `workflow_dispatch:` from the `on:` block. Add an inline comment documenting why it's absent so the next person who wants "a manual deploy button for testing" understands the guardrail and proposes a different mechanism instead of just re-adding the line.

## Out of scope

The current cli.deepgram.com is showing `0.2.20` while PyPI tops out at `0.2.19`. Fixing that is a separate decision — either:
- wait for the next release-please cycle to actually ship `0.2.20` to PyPI, at which point the deployed page becomes correct
- revert the deploy by triggering an old-version build (not possible with this PR's restrictions, intentionally)

I'm not going to touch the live site again without explicit direction.