### PR TITLE
fix(telemetry): drop web opt-out toggle, document CLI opt-out in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,38 @@ dg profiles --switch staging             # Switch profile
 
 Output format on any command: `--output json|yaml|table|csv`
 
+## Telemetry
+
+The CLI phones home anonymous error reports to help us catch crashes and regressions before users have to file an issue. It's **on by default** and easy to turn off.
+
+**What's collected:** Python exceptions, stack traces, the CLI version, and the Python runtime. Request bodies, headers, cookies, API keys, email addresses, IP addresses, and usernames are scrubbed before send. No performance traces, no profiling, no replays — errors only.
+
+**Where it goes:** the `dx-cli` Sentry project owned by the Deepgram DX team.
+
+### Opt out
+
+Persistent (recommended):
+
+```bash
+dg config set telemetry.enabled false
+```
+
+One-shot (CI, scripts, single command):
+
+```bash
+DEEPCTL_TELEMETRY_DISABLED=1 dg listen recording.wav
+```
+
+### Override the destination
+
+For forks or self-hosted Sentry, point telemetry at your own DSN:
+
+```bash
+export DEEPCTL_TELEMETRY_DSN='https://<key>@<your-sentry>/<project>'
+```
+
+`DEEPCTL_TELEMETRY_DISABLED` always wins. The default DSN is baked into the package and only used when the override is unset.
+
 ## Development
 
 ```bash

--- a/web/sentry.client.config.ts
+++ b/web/sentry.client.config.ts
@@ -1,17 +1,10 @@
 import * as Sentry from '@sentry/astro';
 
-const STORAGE_KEY = 'dg_telemetry';
-const optedOut =
-  typeof window !== 'undefined' &&
-  window.localStorage?.getItem(STORAGE_KEY) === 'off';
-
-if (!optedOut) {
-  Sentry.init({
-    dsn: 'https://d7a2aabbf772218e3bbe89266999af70@o206115.ingest.us.sentry.io/4510993603362816',
-    environment: import.meta.env.PROD ? 'production' : 'development',
-    sendDefaultPii: false,
-    tracesSampleRate: 0,
-    replaysSessionSampleRate: 0,
-    replaysOnErrorSampleRate: 0,
-  });
-}
+Sentry.init({
+  dsn: 'https://d7a2aabbf772218e3bbe89266999af70@o206115.ingest.us.sentry.io/4510993603362816',
+  environment: import.meta.env.PROD ? 'production' : 'development',
+  sendDefaultPii: false,
+  tracesSampleRate: 0,
+  replaysSessionSampleRate: 0,
+  replaysOnErrorSampleRate: 0,
+});

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -862,10 +862,6 @@ const commandCards: CommandCard[] = [
       </div>
       <div class="pt-6 text-[11px] text-dg-pebble flex flex-col sm:flex-row justify-between gap-2" style="border-top: 1px solid #2c2c3330;">
         <span>© {new Date().getFullYear()} Deepgram, Inc. All rights reserved.</span>
-        <span>
-          Telemetry: <span id="dg-tel-state">on</span>
-          <button id="dg-tel-toggle" type="button" class="ml-2 underline hover:text-dg-text transition-colors">toggle</button>
-        </span>
       </div>
     </div>
   </footer>
@@ -1103,26 +1099,4 @@ const commandCards: CommandCard[] = [
   (window as any).switchInstall = switchInstall;
   (window as any).copyInstall = copyInstall;
   (window as any).copyCmd = copyCmd;
-
-  // ── Telemetry opt-out toggle ─────────────────────────────────
-  // Reads/writes the `dg_telemetry` localStorage flag. Sentry init
-  // in sentry.client.config.ts checks the same flag on page load.
-  (() => {
-    const STORAGE_KEY = 'dg_telemetry';
-    const stateEl = document.getElementById('dg-tel-state');
-    const toggleEl = document.getElementById('dg-tel-toggle');
-    if (!stateEl || !toggleEl) return;
-    const render = () => {
-      const off = localStorage.getItem(STORAGE_KEY) === 'off';
-      stateEl.textContent = off ? 'off' : 'on';
-    };
-    toggleEl.addEventListener('click', () => {
-      const off = localStorage.getItem(STORAGE_KEY) === 'off';
-      if (off) localStorage.removeItem(STORAGE_KEY);
-      else localStorage.setItem(STORAGE_KEY, 'off');
-      render();
-      location.reload();
-    });
-    render();
-  })();
 </script>


### PR DESCRIPTION
## Summary

Follow-up to #59. Three small fixes:

1. **Drop the web footer toggle** on `cli.deepgram.com`. The marketing site's Sentry init is non-opt-outable error/uptime monitoring — same model as every other public Deepgram web property. The toggle implied the visitor had agency over it, which they don't.
2. **Drop the `localStorage.dg_telemetry` gate** in `web/sentry.client.config.ts`. Without the toggle UI it was dead code, but it also let a power user disable site error monitoring via DevTools, which is not the intent. Sentry init is now unconditional for site visitors.
3. **Document CLI opt-out in the main README**. The three paths (`dg config set telemetry.enabled false`, `DEEPCTL_TELEMETRY_DISABLED=1`, `DEEPCTL_TELEMETRY_DSN`) were only discoverable via `--help` or source code. Now they live in a `## Telemetry` section right after `## Configuration` with what's collected, what's scrubbed, and where it lands.

## Why two telemetry surfaces, one opt-out story

| Surface | Runs where | Opt-out |
|---|---|---|
| `cli.deepgram.com` Sentry | Visitor's browser, our marketing site | None — site error monitoring, owned by us |
| `deepctl` Sentry | User's local machine, our installed binary | Three documented paths |

The CLI phones home from the user's machine on user-side stack traces, so opt-out is mandatory and has to be discoverable. The website Sentry catches our own bugs in our own code on our own deployed site. Different consent model, different surface.

## Test plan

- `web/sentry.client.config.ts` — Sentry init runs unconditionally; no `localStorage` reads
- `web/src/pages/index.astro` — footer is just the copyright line; grep for `dg-tel` / `dg_telemetry` / `Telemetry: ` returns nothing
- `README.md` — new `## Telemetry` section between `## Configuration` and `## Development`

## Related

- #59 — original implementation (merged)