### PR TITLE
ci(release): gate mark-latest and web deploy on PyPI publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,10 +79,12 @@ jobs:
 
   mark-latest:
     name: Mark root release as latest
-    needs: release-please
-    # Re-assert latest on the root package tag (vX.Y.Z) after all sub-package
-    # releases are created, since release-please processes them sequentially and
-    # a sub-package release created after the root tag can steal the pointer.
+    needs: [release-please, publish]
+    # Re-assert latest on the root package tag (vX.Y.Z) after PyPI publish so
+    # users clicking "latest" land on a tag whose artifact is actually
+    # installable. Also re-asserts after all sub-package releases since
+    # release-please processes them sequentially and a sub-package release
+    # created after the root tag can steal the pointer.
     if: |
       needs.release-please.outputs.release_created == 'true' &&
       startsWith(needs.release-please.outputs.tag_name, 'v')
@@ -95,9 +97,11 @@ jobs:
 
   deploy-web:
     name: Deploy web to production
-    needs: release-please
-    # Only fire on root-package releases (v0.2.4, v1.0.0, …).
-    # Sub-package tags look like deepctl-cmd-listen-v0.0.3 — skip those.
+    needs: [release-please, publish]
+    # Only fire on root-package releases (v0.2.4, v1.0.0, …) and only after
+    # PyPI publish so cli.deepgram.com never advertises a version that isn't
+    # installable yet. Sub-package tags look like deepctl-cmd-listen-v0.0.3 —
+    # skip those.
     if: |
       needs.release-please.outputs.release_created == 'true' &&
       startsWith(needs.release-please.outputs.tag_name, 'v')


### PR DESCRIPTION
## Summary

Move \`mark-latest\` and the cli.deepgram.com production deploy downstream of \`publish\` so they run in parallel with \`bump-brew-formula\` instead of in parallel with \`build\` / \`test\` / \`publish\`.

## Why

PyPI is the gating artifact for everything that follows a release. Today:

- \`mark-latest\` could flip the "latest" pointer on a tag whose PyPI artifact hadn't been published yet — a user clicking "latest" would land on a 404.
- \`deploy-web\` could ship a new cli.deepgram.com banner advertising \`pip install deepctl@X.Y.Z\` before that version existed on PyPI.
- \`bump-brew-formula\` was already correctly downstream of \`publish\` (it needs the published SHA).

Now all three downstream-of-publish jobs share the same correctness invariant: nothing promotes a release until PyPI says it exists.

## Job graph

Before:

\`\`\`
release-please ─┬─> build ─> test ─> publish ─> bump-brew-formula
                ├─> mark-latest
                └─> deploy-web
\`\`\`

After:

\`\`\`
release-please ─> build ─> test ─> publish ─┬─> mark-latest
                                            ├─> deploy-web
                                            └─> bump-brew-formula
\`\`\`

## Diff

Two job definitions changed — \`needs: release-please\` ➜ \`needs: [release-please, publish]\`. Comments updated to capture the installability invariant. Total: +11 / -7.