### PR TITLE
fix(listen): restrict feature prompt to bare-invocation guided flow

### DIFF
--- a/packages/deepctl-cmd-listen/src/deepctl_cmd_listen/command.py
+++ b/packages/deepctl-cmd-listen/src/deepctl_cmd_listen/command.py
@@ -258,6 +258,7 @@ class ListenCommand(BaseCommand):
     ) -> BaseResult:
         source: str | None = kwargs.get("source")
         use_mic: bool = kwargs.get("mic", False)
+        guided_flow = False
 
         # ── Resolve mode ───────────────────────────────────────────────
         if source == "-":
@@ -280,12 +281,12 @@ class ListenCommand(BaseCommand):
                 ),
             )
         else:
-            # Interactive: ask the user
             selected_mode, selected_source = self._interactive_select_source()
             if not selected_mode:
                 return BaseResult(status="cancelled", message="Cancelled.")
             mode = selected_mode
             source = selected_source
+            guided_flow = True
 
         # ── Gather options ─────────────────────────────────────────────
         model = kwargs.get("model") or "nova-3"
@@ -322,13 +323,7 @@ class ListenCommand(BaseCommand):
         if caption_format and not diarize:
             diarize = False  # keep explicit — user can add --diarize themselves
 
-        # Interactive feature selection when user chose source interactively
-        # (signals they want a guided experience)
-        if (
-            not _agentic
-            and mode in ("prerecorded_file", "prerecorded_url")
-            and not any([diarize, summarize, topics, sentiment])
-        ):
+        if guided_flow and mode in ("prerecorded_file", "prerecorded_url"):
             diarize, summarize, topics, sentiment = self._interactive_features()
 
         # ── Dispatch ───────────────────────────────────────────────────

--- a/packages/deepctl-cmd-listen/tests/unit/test_listen_command.py
+++ b/packages/deepctl-cmd-listen/tests/unit/test_listen_command.py
@@ -241,6 +241,98 @@ class TestListenCommand:
             assert result.source == "stdin"
 
 
+class TestGuidedFlow:
+    """Verify the guided-flow gate: prompts only fire on bare `dg listen`."""
+
+    @pytest.fixture
+    def command(self):
+        return ListenCommand()
+
+    @pytest.fixture
+    def common_kwargs(self):
+        return {
+            "client": Mock(spec=DeepgramClient),
+            "config": Mock(spec=Config),
+            "auth_manager": Mock(spec=AuthManager),
+        }
+
+    def test_url_arg_skips_both_prompts(self, command, common_kwargs):
+        with patch.object(command, "_interactive_features") as feat, patch.object(
+            command, "_interactive_select_source"
+        ) as src, patch.object(
+            command, "_prerecorded", return_value=BaseResult(status="ok")
+        ):
+            command.handle(
+                **common_kwargs, source="https://example.com/audio.wav"
+            )
+        assert feat.call_count == 0
+        assert src.call_count == 0
+
+    def test_file_arg_skips_both_prompts(self, command, common_kwargs):
+        with patch.object(command, "_interactive_features") as feat, patch.object(
+            command, "_interactive_select_source"
+        ) as src, patch.object(
+            command, "_prerecorded", return_value=BaseResult(status="ok")
+        ):
+            command.handle(**common_kwargs, source="/tmp/audio.wav")
+        assert feat.call_count == 0
+        assert src.call_count == 0
+
+    def test_url_arg_with_diarize_skips_both_prompts(
+        self, command, common_kwargs
+    ):
+        with patch.object(command, "_interactive_features") as feat, patch.object(
+            command, "_interactive_select_source"
+        ) as src, patch.object(
+            command, "_prerecorded", return_value=BaseResult(status="ok")
+        ):
+            command.handle(
+                **common_kwargs,
+                source="https://example.com/audio.wav",
+                diarize=True,
+            )
+        assert feat.call_count == 0
+        assert src.call_count == 0
+
+    def test_bare_invocation_runs_full_guided_flow(
+        self, command, common_kwargs
+    ):
+        with patch.object(
+            command,
+            "_interactive_features",
+            return_value=(False, False, False, False),
+        ) as feat, patch.object(
+            command,
+            "_interactive_select_source",
+            return_value=("prerecorded_url", "https://x.com/a.wav"),
+        ) as src, patch.object(
+            command, "_prerecorded", return_value=BaseResult(status="ok")
+        ), patch(
+            "sys.stdin"
+        ) as mock_stdin, patch(
+            "deepctl_cmd_listen.command._agentic", False
+        ):
+            mock_stdin.isatty.return_value = True
+            command.handle(**common_kwargs)
+        assert src.call_count == 1
+        assert feat.call_count == 1
+
+    def test_cancelled_source_select_returns_cancelled(
+        self, command, common_kwargs
+    ):
+        with patch.object(
+            command, "_interactive_select_source", return_value=(None, None)
+        ), patch.object(command, "_interactive_features") as feat, patch(
+            "sys.stdin"
+        ) as mock_stdin, patch(
+            "deepctl_cmd_listen.command._agentic", False
+        ):
+            mock_stdin.isatty.return_value = True
+            result = command.handle(**common_kwargs)
+        assert result.status == "cancelled"
+        assert feat.call_count == 0
+
+
 class TestListenResult:
     """Test ListenResult model fields and defaults."""
 


### PR DESCRIPTION
## The bug

\`\`\`
$ dg listen https://dpgr.am/spacewalk.wav | cat
Optional features (press Enter to skip all):
  Speaker diarization [Speaker 0] / [Speaker 1] … [y/n] (n):
\`\`\`

The moment the user provides any source/flag/value, they're scripting — they should never see the optional-features prompt. Today it fires whenever they didn't also pass one of \`--diarize\`/\`--summarize\`/\`--topics\`/\`--sentiment\`.

## The fix

The interactive feature prompt belongs to the bare-\`dg listen\` guided flow only. Lift the \`_interactive_features()\` call into the same branch as \`_interactive_select_source()\`, kill the standalone gate, and anchor the check on a local \`guided_flow\` boolean that flips \`True\` only when the user invokes \`dg listen\` with nothing.

## Behaviour matrix

| Invocation | Source select | Feature prompt |
|---|---|---|
| \`dg listen\` | ✅ asked | ✅ asked |
| \`dg listen URL\` | ❌ skipped | ❌ skipped |
| \`dg listen FILE\` | ❌ skipped | ❌ skipped |
| \`dg listen URL --diarize\` | ❌ skipped | ❌ skipped |
| \`dg listen --mic\` | ❌ skipped | ❌ skipped |
| \`dg listen URL \| cat\` | ❌ skipped | ❌ skipped |
| \`echo audio \| dg listen\` | ❌ skipped (stdin mode) | ❌ skipped |

## Tests

5 new cases in \`TestGuidedFlow\`:

- \`test_url_arg_skips_both_prompts\`
- \`test_file_arg_skips_both_prompts\`
- \`test_url_arg_with_diarize_skips_both_prompts\`
- \`test_bare_invocation_runs_full_guided_flow\`
- \`test_cancelled_source_select_returns_cancelled\`

All 16 listen tests pass: \`uv run pytest packages/deepctl-cmd-listen/tests/unit/test_listen_command.py\` → 16 passed in 0.79s.

## Stack

This is **PR-C** of a three-PR sequence agreed in the analyse-mode review:

- **C** *(this PR)* — \`dg listen\` 'any arg = non-interactive'
- **B** — flag restructure: rename current \`--agent-friendly\` (metadata + exit) → \`--introspect\`; redefine \`--agent-friendly\` global = non-interactive + JSON; add \`--json\` global alias
- **A** — argv-injection bootstrap: soft signals prepend \`--agent-friendly\` to \`sys.argv\`, \`is_agentic()\` collapses to a pure argv check