### PR TITLE
ci(release): switch PyPI watch to JSON API instead of pip index

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,8 +147,13 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="${TAG_NAME#v}"
+          # Poll the PyPI JSON API rather than `pip index versions`. The
+          # JSON endpoint flips the moment a release is published, while
+          # the simple index pip queries can lag 5-15 minutes behind a
+          # successful publish (CDN caching of project metadata).
+          URL="https://pypi.org/pypi/deepctl/${VERSION}/json"
           for i in $(seq 1 30); do
-            if pip index versions deepctl 2>&1 | grep -qE "(^|[^.0-9])${VERSION}([^.0-9]|$)"; then
+            if [ "$(curl -fsS -o /dev/null -w '%{http_code}' "${URL}")" = "200" ]; then
               echo "deepctl==${VERSION} is live on PyPI"
               exit 0
             fi


### PR DESCRIPTION
## Problem

The "Wait for new deepctl version on PyPI" step in [`.github/workflows/release.yml`](https://github.com/deepgram/cli/blob/main/.github/workflows/release.yml#L146-L159) polls `pip index versions deepctl`. That endpoint queries PyPI's simple index, which sits behind a CDN cache that can lag 5-15 minutes after a release is actually published.

Two consecutive releases hit this:

- **v0.2.21** → [homebrew-tap#3](https://github.com/deepgram/homebrew-tap/pull/3) (manual bump)
- **v0.2.22** → [homebrew-tap#4](https://github.com/deepgram/homebrew-tap/pull/4) (manual bump)

In both cases PyPI confirmed the release was installable (any user could `pip install deepctl==X.Y.Z`), but the cached index hadn't picked it up before the 10-minute window (30 × 20s) ran out. The `bump-brew-formula` job failed → we had to regenerate the formula manually.

## Fix

`GET https://pypi.org/pypi/deepctl/<version>/json` — the PyPI JSON API endpoint flips to HTTP 200 the instant a release is published, no CDN cache between us and the source-of-truth catalog.

```bash
URL="https://pypi.org/pypi/deepctl/${VERSION}/json"
if [ "$(curl -fsS -o /dev/null -w '%{http_code}' "${URL}")" = "200" ]; then
  echo "deepctl==${VERSION} is live on PyPI"
  exit 0
fi
```

Same 30 × 20s loop shape, total worst-case budget unchanged at 10 minutes. Typical wait should drop from 5-15 minutes to a single iteration.

## Verification

While diagnosing v0.2.22 today:

```
$ curl -fsS -o /dev/null -w "HTTP %{http_code}\n" https://pypi.org/pypi/deepctl/0.2.22/json
HTTP 200

$ pip index versions deepctl
deepctl (0.2.21)        # ← still didn't see 0.2.22
```

JSON API: live. Simple index: lagging. The fix is to probe the source of truth.

## What it doesn't change

- The 30 × 20s budget shape is preserved so we don't accidentally let bad releases through faster than the existing flow.
- `bump-brew-formula`'s downstream pipeline (`homebrew-pypi-poet` resource generation, etc.) is unchanged. That step's own `pip install deepctl==<version>` may still hit the simple-index lag for ~30-60s after this watch step succeeds, but that's a much smaller window and the install retry is implicit in the script's own behaviour.