### PR TITLE
feat(telemetry): enable session tracking and flush envelopes on exit

### DIFF
--- a/packages/deepctl-telemetry/src/deepctl_telemetry/client.py
+++ b/packages/deepctl-telemetry/src/deepctl_telemetry/client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import atexit
 import os
 import platform
 import sys
@@ -62,6 +63,7 @@ def init_telemetry(config: Config) -> bool:
         release=f"deepctl@{cli_version}",
         environment="production",
         send_default_pii=False,
+        auto_session_tracking=True,
         traces_sample_rate=0.0,
         profiles_sample_rate=0.0,
         max_breadcrumbs=20,
@@ -76,8 +78,20 @@ def init_telemetry(config: Config) -> bool:
     )
     sentry_sdk.set_tag("cli.version", cli_version)
 
+    atexit.register(_flush_on_exit)
+
     _initialized = True
     return True
+
+
+def _flush_on_exit() -> None:
+    """Flush queued envelopes before process exit (best-effort, 2s budget)."""
+    try:
+        import sentry_sdk
+
+        sentry_sdk.flush(timeout=2.0)
+    except Exception:
+        pass
 
 
 def _read_cli_version() -> str:

--- a/packages/deepctl-telemetry/tests/unit/test_telemetry.py
+++ b/packages/deepctl-telemetry/tests/unit/test_telemetry.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
-from deepctl_telemetry import is_enabled, render_notice
+import pytest
+
+from deepctl_telemetry import init_telemetry, is_enabled, render_notice
 from deepctl_telemetry.client import DISABLE_ENV_VAR
 
 
@@ -35,3 +37,60 @@ class TestRenderNotice:
     def test_off_message(self) -> None:
         notice = render_notice(_config(False))
         assert "Telemetry is off" in notice
+
+
+class TestSessionFlush:
+    """Verify init_telemetry enables session tracking and registers atexit flush."""
+
+    @pytest.fixture(autouse=True)
+    def reset_initialized(self) -> None:
+        from deepctl_telemetry import client
+
+        client._initialized = False
+        yield
+        client._initialized = False
+
+    def test_init_enables_auto_session_tracking(self) -> None:
+        with patch("deepctl_telemetry.client.atexit.register"), patch(
+            "sentry_sdk.init"
+        ) as mock_init, patch("sentry_sdk.set_tag"):
+            init_telemetry(_config(True))
+
+        assert mock_init.called
+        kwargs = mock_init.call_args.kwargs
+        assert kwargs["auto_session_tracking"] is True
+        assert kwargs["traces_sample_rate"] == 0.0
+        assert kwargs["profiles_sample_rate"] == 0.0
+
+    def test_init_registers_atexit_flush(self) -> None:
+        from deepctl_telemetry.client import _flush_on_exit
+
+        with patch(
+            "deepctl_telemetry.client.atexit.register"
+        ) as mock_register, patch("sentry_sdk.init"), patch("sentry_sdk.set_tag"):
+            init_telemetry(_config(True))
+
+        mock_register.assert_called_once_with(_flush_on_exit)
+
+    def test_disabled_does_not_register_atexit(self) -> None:
+        with patch(
+            "deepctl_telemetry.client.atexit.register"
+        ) as mock_register, patch("sentry_sdk.init") as mock_init:
+            init_telemetry(_config(False))
+
+        assert not mock_init.called
+        assert not mock_register.called
+
+    def test_flush_on_exit_calls_sentry_flush_with_2s_budget(self) -> None:
+        from deepctl_telemetry.client import _flush_on_exit
+
+        with patch("sentry_sdk.flush") as mock_flush:
+            _flush_on_exit()
+
+        mock_flush.assert_called_once_with(timeout=2.0)
+
+    def test_flush_on_exit_swallows_exceptions(self) -> None:
+        from deepctl_telemetry.client import _flush_on_exit
+
+        with patch("sentry_sdk.flush", side_effect=RuntimeError("boom")):
+            _flush_on_exit()


### PR DESCRIPTION
## Why

Today the \`dx-cli\` Sentry project has zero events. That's expected for an errors-only telemetry contract on a CLI that's been live <24h — most users haven't hit an unhandled exception. But it also means there's no signal at all: we can't tell "is anyone running v0.2.22?" from the dashboard.

Sessions fix that without violating the errors-only design.

## What changed

Two lines in \`packages/deepctl-telemetry/src/deepctl_telemetry/client.py\`:

\`\`\`python
sentry_sdk.init(
    ...
    auto_session_tracking=True,   # NEW (already the SDK default; explicit now)
    traces_sample_rate=0.0,        # unchanged
    profiles_sample_rate=0.0,      # unchanged
    ...
)

atexit.register(_flush_on_exit)    # NEW
\`\`\`

Plus a tiny module-level helper:

\`\`\`python
def _flush_on_exit() -> None:
    try:
        import sentry_sdk
        sentry_sdk.flush(timeout=2.0)
    except Exception:
        pass
\`\`\`

## What it gives us

After the next release lands on PyPI and a few users invoke \`dg\`:

- [Releases dashboard](https://deepgram.sentry.io/releases/?project=4510993603362816) populates with per-version session counts.
- Crash-free session % per release, the canonical CLI health metric.
- Stable signal that "the new version actually launched on someone's machine" without per-command instrumentation.

## What it doesn't change

- \`traces_sample_rate=0\` and \`profiles_sample_rate=0\` are unchanged — no transactions, no profiles.
- No new PII paths. \`before_send\` scrubbing applies to error envelopes; session envelopes carry only release tag, environment, and start/end timestamps.
- Opt-out paths (\`dg config set telemetry.enabled false\`, \`DEEPCTL_TELEMETRY_DISABLED=1\`, \`--non-interactive\` once #67 lands) all skip session tracking too — \`init_telemetry\` returns early before \`atexit.register\` is reached, verified by \`test_disabled_does_not_register_atexit\`.

## Why \`atexit\` and not \`Sentry.flush()\` inline somewhere

CLI commands have multiple exit paths — \`return BaseResult(...)\`, raised exceptions, \`ctx.exit()\` from Click, sys.exit on signal, etc. \`atexit\` is the only hook that fires on all of them. The 2-second budget caps user-visible exit delay even if Sentry is unreachable. The bare-\`except\` ensures a Sentry hang can never block process termination.

## Test plan

5 new cases in \`TestSessionFlush\`:

- \`test_init_enables_auto_session_tracking\` — kwargs dict on \`sentry_sdk.init\` includes \`auto_session_tracking=True\` and confirms \`traces_sample_rate==0\`, \`profiles_sample_rate==0\` are still in place.
- \`test_init_registers_atexit_flush\` — \`atexit.register\` called once with the \`_flush_on_exit\` function reference.
- \`test_disabled_does_not_register_atexit\` — when \`is_enabled\` returns False, neither \`sentry_sdk.init\` nor \`atexit.register\` fires.
- \`test_flush_on_exit_calls_sentry_flush_with_2s_budget\` — \`sentry_sdk.flush(timeout=2.0)\` is the call shape.
- \`test_flush_on_exit_swallows_exceptions\` — Sentry raising during flush does not propagate.

Full suite: \`uv run pytest packages/deepctl-telemetry/tests/\` → 10 passed in 0.06s.