### PR TITLE
fix(telemetry): explicitly start session after init

### DIFF
--- a/packages/deepctl-telemetry/src/deepctl_telemetry/client.py
+++ b/packages/deepctl-telemetry/src/deepctl_telemetry/client.py
@@ -78,6 +78,7 @@ def init_telemetry(config: Config) -> bool:
     )
     sentry_sdk.set_tag("cli.version", cli_version)
 
+    sentry_sdk.start_session()
     atexit.register(_flush_on_exit)
 
     _initialized = True

--- a/packages/deepctl-telemetry/tests/unit/test_telemetry.py
+++ b/packages/deepctl-telemetry/tests/unit/test_telemetry.py
@@ -53,7 +53,9 @@ class TestSessionFlush:
     def test_init_enables_auto_session_tracking(self) -> None:
         with patch("deepctl_telemetry.client.atexit.register"), patch(
             "sentry_sdk.init"
-        ) as mock_init, patch("sentry_sdk.set_tag"):
+        ) as mock_init, patch("sentry_sdk.set_tag"), patch(
+            "sentry_sdk.start_session"
+        ):
             init_telemetry(_config(True))
 
         assert mock_init.called
@@ -61,16 +63,27 @@ class TestSessionFlush:
         assert kwargs["auto_session_tracking"] is True
         assert kwargs["traces_sample_rate"] == 0.0
         assert kwargs["profiles_sample_rate"] == 0.0
+        assert "session_mode" not in kwargs
 
     def test_init_registers_atexit_flush(self) -> None:
         from deepctl_telemetry.client import _flush_on_exit
 
         with patch(
             "deepctl_telemetry.client.atexit.register"
-        ) as mock_register, patch("sentry_sdk.init"), patch("sentry_sdk.set_tag"):
+        ) as mock_register, patch("sentry_sdk.init"), patch(
+            "sentry_sdk.set_tag"
+        ), patch("sentry_sdk.start_session"):
             init_telemetry(_config(True))
 
         mock_register.assert_called_once_with(_flush_on_exit)
+
+    def test_init_starts_session(self) -> None:
+        with patch("sentry_sdk.init"), patch("sentry_sdk.set_tag"), patch(
+            "deepctl_telemetry.client.atexit.register"
+        ), patch("sentry_sdk.start_session") as mock_start:
+            init_telemetry(_config(True))
+
+        mock_start.assert_called_once_with()
 
     def test_disabled_does_not_register_atexit(self) -> None:
         with patch(


### PR DESCRIPTION
## The bug

[#71](https://github.com/deepgram/cli/pull/71) enabled `auto_session_tracking=True` expecting sentry-sdk to start sessions automatically. It doesn't — in sentry-sdk 2.x, that flag only tells **integrations** (Flask, Django, ASGI request handlers) to wrap each request in a session. CLIs have no integration that knows when an 'application session' begins, so no session is ever created.

Confirmed via `SENTRY_DEBUG=1`: the worker flushed but no `Sending envelope` line ever appeared, and the [Releases dashboard](https://deepgram.sentry.io/releases/?project=4510993603362816) showed zero `deepctl@*` releases despite #71 having shipped.

## The fix

One line — call `sentry_sdk.start_session()` right after init. Default `session_mode` is already `"application"` per [scope.py L1558](https://github.com/getsentry/sentry-python/blob/2.59.0/sentry_sdk/scope.py#L1558). The atexit handler from #71 then catches the session in its flush.

```python
sentry_sdk.init(...)             # unchanged
sentry_sdk.set_tag(...)          # unchanged
sentry_sdk.start_session()       # NEW
atexit.register(_flush_on_exit)  # unchanged
```

## Proof

Pre-fix `SENTRY_DEBUG=1` (worker flushes empty queue):

```
[sentry] DEBUG: Flushing HTTP transport
[sentry] DEBUG: background worker got flush request
[sentry] DEBUG: background worker flushed
[sentry] DEBUG: atexit: got shutdown signal
[sentry] DEBUG: Killing HTTP transport
```

Post-fix:

```
[sentry] DEBUG: atexit: got shutdown signal
[sentry] DEBUG: Flushing HTTP transport
[sentry] DEBUG: Sending envelope [envelope with 1 items (session)] project:4510993603362816 host:o206115.ingest.us.sentry.io
```

The session envelope ships to the `dx-cli` project (id `4510993603362816`).

## Bonus catch — the silent failure that masked this

While diagnosing, my first attempt was `session_mode="application"` as an init kwarg. sentry-sdk 2.59.0 raises `TypeError: Unknown option 'session_mode'` for that, which the `try/except: pass` wrapper in `src/deepctl/main.py` silently swallowed. The CLI ran fine; telemetry was just dead.

Added a regression test (`assert 'session_mode' not in kwargs`) so a future kwargs change can't reintroduce that failure.

## Tests

```
11 passed in 0.04s
```

New: `test_init_starts_session` asserts `sentry_sdk.start_session()` is called once after init. Updated `test_init_enables_auto_session_tracking` with the `session_mode` regression guard.