### PR TITLE
fix(mcp): survive stdio host disconnect and silence handled MCP noise

### DIFF
--- a/packages/deepctl-cmd-mcp/src/deepctl_cmd_mcp/command.py
+++ b/packages/deepctl-cmd-mcp/src/deepctl_cmd_mcp/command.py
@@ -8,16 +8,19 @@ import signal
 from typing import TYPE_CHECKING, Any
 
 from deepctl_core import AuthManager, BaseCommand, Config, DeepgramClient
+from deepctl_core.output import stderr_console
 from deepgram_mcp import TransportType, run_proxy
 from deepgram_mcp.proxy import DEFAULT_BASE_URL
-from rich.console import Console
 
 from .models import MCPServerResult
 
 if TYPE_CHECKING:
     pass
 
-console = Console()
+# Use stderr for all output: when `dg mcp --transport stdio` is invoked by an
+# MCP host (Claude Desktop, Codex, etc.), stdout is the JSON-RPC protocol
+# channel and must not receive any human-readable messages.
+console = stderr_console
 
 
 class McpCommand(BaseCommand):
@@ -151,12 +154,18 @@ class McpCommand(BaseCommand):
                 )
             )
 
+            if transport == "stdio":
+                # The MCP host owns stdout (JSON-RPC channel) and typically
+                # closes it on disconnect, so we return None to skip
+                # output_result rather than risk a write to a closed stream.
+                return None
+
             return MCPServerResult(
                 status="success",
                 message="MCP proxy stopped",
                 transport=TransportType(transport),
-                port=port if transport != "stdio" else None,
-                host=host if transport != "stdio" else None,
+                port=port,
+                host=host,
             )
 
         except KeyboardInterrupt:

--- a/packages/deepctl-cmd-mcp/tests/unit/test_mcp_command.py
+++ b/packages/deepctl-cmd-mcp/tests/unit/test_mcp_command.py
@@ -74,8 +74,13 @@ class TestMcpCommand:
 
     @patch("deepctl_cmd_mcp.command.asyncio.run")
     @patch("signal.signal")
-    def test_handle_stdio_transport(self, mock_signal, mock_asyncio_run):
-        """Test handling stdio transport calls asyncio.run with run_proxy."""
+    def test_handle_stdio_transport_returns_none(self, mock_signal, mock_asyncio_run):
+        """stdio mode returns None so the host's owned stdout is never written to.
+
+        Returning a result would invite ``output_result`` to print to stdout,
+        which the MCP host has typically closed. See DX-CLI-4/DX-CLI-5 in
+        Sentry for the regression we're guarding against.
+        """
         command = McpCommand()
         config = MagicMock()
         auth_manager = MagicMock()
@@ -93,9 +98,7 @@ class TestMcpCommand:
         )
 
         mock_asyncio_run.assert_called_once()
-        assert isinstance(result, MCPServerResult)
-        assert result.status == "success"
-        assert result.transport == TransportType.STDIO
+        assert result is None
 
     @patch("deepctl_cmd_mcp.command.asyncio.run")
     @patch("signal.signal")
@@ -204,5 +207,5 @@ class TestMcpCommand:
                 transport="stdio",
             )
 
-        assert result.status == "success"
+        assert result is None
         mock_run.assert_called_once()

--- a/packages/deepctl-core/src/deepctl_core/base_command.py
+++ b/packages/deepctl-core/src/deepctl_core/base_command.py
@@ -121,7 +121,16 @@ class BaseCommand(ABC):
                 # Handle command result
                 if result is not None:
                     with TimingContext("output_processing"):
-                        self.output_result(result, config)
+                        try:
+                            self.output_result(result, config)
+                        except (BrokenPipeError, OSError):
+                            # Downstream stream closed (e.g. an MCP host disconnected
+                            # stdio after `dg mcp` finished). Nothing useful to log
+                            # here because the logger writes to the same closed stream.
+                            pass
+                        except ValueError as exc:
+                            if "closed file" not in str(exc):
+                                raise
 
             except KeyboardInterrupt:
                 self._tag_telemetry_status("cancelled")

--- a/packages/deepctl-core/tests/unit/test_base.py
+++ b/packages/deepctl-core/tests/unit/test_base.py
@@ -1270,3 +1270,96 @@ def _param(name):
     p = Mock()
     p.name = name
     return p
+
+
+class TestExecuteStreamSafety:
+    """The execute loop must not crash when stdout/stderr is closed.
+
+    Background: ``dg mcp --transport stdio`` runs under an MCP host (Claude
+    Desktop, Codex, etc.) which closes stdio when it disconnects. Any
+    write to the closed stream after that point raises ``ValueError:
+    I/O operation on closed file`` or ``BrokenPipeError``. We trap these
+    around the ``output_result`` call so the CLI exits cleanly instead of
+    surfacing a confusing crash to the user (or to Sentry).
+
+    See DX-CLI-4 / DX-CLI-5 in Sentry.
+    """
+
+    @pytest.fixture
+    def mock_command_class(self):
+        class MockCommand(BaseCommand):
+            name = "test"
+            help = "Test command"
+
+            def handle(
+                self,
+                config: Config,
+                auth_manager: AuthManager,
+                client: DeepgramClient,
+                **kwargs: Any,
+            ) -> Any:
+                return {"result": "ok"}
+
+        return MockCommand
+
+    @pytest.fixture
+    def mock_context(self):
+        ctx = Mock(spec=click.Context)
+        ctx.obj = {"config": Config()}
+        return ctx
+
+    @pytest.mark.unit
+    @patch("deepctl_core.base_command.AuthManager")
+    @patch("deepctl_core.base_command.DeepgramClient")
+    def test_execute_swallows_closed_stdout_value_error(
+        self,
+        _client_class,
+        _auth_class,
+        mock_command_class,
+        mock_context,
+    ):
+        command = mock_command_class()
+        with patch.object(
+            command,
+            "output_result",
+            side_effect=ValueError("I/O operation on closed file."),
+        ):
+            command.execute(mock_context)
+
+    @pytest.mark.unit
+    @patch("deepctl_core.base_command.AuthManager")
+    @patch("deepctl_core.base_command.DeepgramClient")
+    def test_execute_swallows_broken_pipe(
+        self,
+        _client_class,
+        _auth_class,
+        mock_command_class,
+        mock_context,
+    ):
+        command = mock_command_class()
+        with patch.object(
+            command,
+            "output_result",
+            side_effect=BrokenPipeError(),
+        ):
+            command.execute(mock_context)
+
+    @pytest.mark.unit
+    @patch("deepctl_core.base_command.AuthManager")
+    @patch("deepctl_core.base_command.DeepgramClient")
+    def test_execute_propagates_unrelated_value_error(
+        self,
+        _client_class,
+        _auth_class,
+        mock_command_class,
+        mock_context,
+    ):
+        """A ValueError that isn't about a closed stream is a real bug, surface it."""
+        command = mock_command_class()
+        with patch.object(
+            command,
+            "output_result",
+            side_effect=ValueError("totally unrelated"),
+        ):
+            with pytest.raises(click.ClickException):
+                command.execute(mock_context)

--- a/packages/deepctl-telemetry/src/deepctl_telemetry/client.py
+++ b/packages/deepctl-telemetry/src/deepctl_telemetry/client.py
@@ -103,13 +103,46 @@ def _read_cli_version() -> str:
     return importlib.metadata.version("deepctl")
 
 
+_MCP_NOISE_LOGGERS = frozenset(
+    {
+        "mcp.client.streamable_http",
+        "mcp.server.lowlevel.server",
+    }
+)
+
+
+def _is_mcp_transient_noise(event: Event) -> bool:
+    """Identify log events from the MCP SDK that are not actionable bugs.
+
+    `dg mcp` embeds the upstream `mcp` Python SDK, which logs to Sentry via
+    the logging integration whenever the upstream MCP server returns 5xx
+    (handled by the client) or the stdio peer closes mid-message (handled by
+    the server). Both are recovered internally. Surfacing them as Sentry
+    issues just creates triage cost for the DX team and hides real CLI bugs.
+
+    Any unhandled exception is kept regardless of logger.
+    """
+    if (event.get("logger") or "") not in _MCP_NOISE_LOGGERS:
+        return False
+    for exc in (event.get("exception") or {}).get("values") or []:
+        mechanism = exc.get("mechanism") or {}
+        if mechanism.get("handled") is False:
+            return False
+    return True
+
+
 def _scrub_event(event: Event, _hint: Hint) -> Event | None:
     """Drop request bodies, headers, and any user-identifying data.
 
     Sentry SDK already filters most PII via send_default_pii=False, but
     Auth tokens, project IDs, and file paths can still leak through
     breadcrumbs and exception messages. This is a defense-in-depth scrub.
+
+    Also drops known-noise events (see ``_is_mcp_transient_noise``).
     """
+    if _is_mcp_transient_noise(event):
+        return None
+
     request: dict[str, Any] = event.get("request") or {}
     if "headers" in request:
         request["headers"] = {}

--- a/packages/deepctl-telemetry/tests/unit/test_telemetry.py
+++ b/packages/deepctl-telemetry/tests/unit/test_telemetry.py
@@ -110,3 +110,121 @@ class TestSessionFlush:
 
         with patch("sentry_sdk.flush", side_effect=RuntimeError("boom")):
             _flush_on_exit()
+
+
+def _handled_log_event(logger: str, exc_type: str, value: str) -> dict:
+    return {
+        "logger": logger,
+        "exception": {
+            "values": [
+                {
+                    "type": exc_type,
+                    "value": value,
+                    "mechanism": {"type": "logging", "handled": True},
+                }
+            ]
+        },
+    }
+
+
+def _message_only_event(logger: str) -> dict:
+    return {"logger": logger}
+
+
+class TestMcpNoiseFilter:
+    """Drop handled MCP SDK log noise so Sentry stays actionable.
+
+    Anchors: DX-CLI-1 (HTTPStatusError 5xx from streamable_http) and
+    DX-CLI-3 (Invalid JSON: EOF from mcp.server.lowlevel.server).
+    Unhandled exceptions are always kept regardless of logger.
+    """
+
+    def test_drops_streamable_http_503_log(self) -> None:
+        from deepctl_telemetry.client import _is_mcp_transient_noise
+
+        event = _handled_log_event(
+            "mcp.client.streamable_http",
+            "HTTPStatusError",
+            "Server error '503 Service Unavailable' for url",
+        )
+        assert _is_mcp_transient_noise(event)
+
+    def test_drops_lowlevel_server_eof_log(self) -> None:
+        from deepctl_telemetry.client import _is_mcp_transient_noise
+
+        event = _message_only_event("mcp.server.lowlevel.server")
+        assert _is_mcp_transient_noise(event)
+
+    def test_keeps_unhandled_exception_from_mcp_logger(self) -> None:
+        """Unhandled crashes are real bugs even if the logger is MCP."""
+        from deepctl_telemetry.client import _is_mcp_transient_noise
+
+        event = {
+            "logger": "mcp.client.streamable_http",
+            "exception": {
+                "values": [
+                    {
+                        "type": "RuntimeError",
+                        "value": "boom",
+                        "mechanism": {"type": "excepthook", "handled": False},
+                    }
+                ]
+            },
+        }
+        assert not _is_mcp_transient_noise(event)
+
+    def test_keeps_non_mcp_logger_events(self) -> None:
+        from deepctl_telemetry.client import _is_mcp_transient_noise
+
+        event = _handled_log_event(
+            "deepctl_core.base_command",
+            "HTTPStatusError",
+            "Server error '503 Service Unavailable' for url",
+        )
+        assert not _is_mcp_transient_noise(event)
+
+    def test_handles_missing_fields(self) -> None:
+        from deepctl_telemetry.client import _is_mcp_transient_noise
+
+        assert not _is_mcp_transient_noise({})
+        assert not _is_mcp_transient_noise({"logger": None})
+        assert not _is_mcp_transient_noise({"logger": "deepctl"})
+        assert _is_mcp_transient_noise({"logger": "mcp.client.streamable_http"})
+
+    def test_scrub_event_returns_none_for_mcp_noise(self) -> None:
+        """The before_send hook drops MCP noise entirely."""
+        from deepctl_telemetry.client import _scrub_event
+
+        event = _handled_log_event(
+            "mcp.client.streamable_http",
+            "HTTPStatusError",
+            "Server error '503 Service Unavailable' for url",
+        )
+        assert _scrub_event(event, {}) is None
+
+    def test_scrub_event_still_scrubs_normal_request_headers(self) -> None:
+        from deepctl_telemetry.client import _scrub_event
+
+        event = {
+            "logger": "deepctl",
+            "request": {
+                "headers": {"Authorization": "Bearer secret"},
+                "cookies": {"sid": "abc"},
+                "data": "{\"raw\":\"body\"}",
+            },
+            "user": {
+                "email": "x@example.com",
+                "ip_address": "1.2.3.4",
+                "username": "x",
+                "id": "user-1",
+            },
+        }
+        result = _scrub_event(event, {})
+        assert result is not None
+        assert result["request"]["headers"] == {}
+        assert result["request"]["cookies"] == {}
+        assert result["request"]["data"] == "[Filtered]"
+        assert "email" not in result["user"]
+        assert "ip_address" not in result["user"]
+        assert "username" not in result["user"]
+        assert result["user"]["id"] == "user-1"


### PR DESCRIPTION
## Summary

`dg mcp --transport stdio` was crashing when the AI host (Claude Desktop, Codex, etc.) closed the JSON-RPC stdio channel on disconnect. Anything that wrote to the global rich `Console` after that raised `ValueError: I/O operation on closed file` and surfaced as an unhandled exception (DX-CLI-4, DX-CLI-5 — **88 events in 14d, 27 in the last hour alone**, still firing as of writing).

This PR adds three layered fixes:

### 1. `dg mcp` writes to stderr and returns None for stdio

[`packages/deepctl-cmd-mcp/src/deepctl_cmd_mcp/command.py`](../tree/fix/mcp-stdio-stream-safety/packages/deepctl-cmd-mcp/src/deepctl_cmd_mcp/command.py)

- Module `console` is now `stderr_console` from `deepctl_core.output`. Writing anything to stdout while the MCP host owns it would corrupt the JSON-RPC stream anyway.
- For `transport=stdio` the handler returns `None` instead of `MCPServerResult`. That skips `BaseCommand.output_result` entirely so there is nothing to write to the closed protocol channel after the proxy exits.
- The other branches (sse, errors, KeyboardInterrupt) keep returning `MCPServerResult`. Those have a real terminal to print to.

### 2. `BaseCommand.execute` traps closed-stream writes around `output_result`

[`packages/deepctl-core/src/deepctl_core/base_command.py`](../tree/fix/mcp-stdio-stream-safety/packages/deepctl-core/src/deepctl_core/base_command.py)

Defense in depth so any future stdio-mode command inherits the same safety. Catches `BrokenPipeError`, `OSError`, and `ValueError("...closed file...")`. Unrelated `ValueError`s still propagate as `ClickException` so real bugs aren't hidden.

### 3. `deepctl-telemetry` drops handled MCP SDK log noise

[`packages/deepctl-telemetry/src/deepctl_telemetry/client.py`](../tree/fix/mcp-stdio-stream-safety/packages/deepctl-telemetry/src/deepctl_telemetry/client.py)

`_scrub_event` now drops events whose `logger` is in:

- `mcp.client.streamable_http` (the upstream MCP returned 5xx, recovered by the client — DX-CLI-1)
- `mcp.server.lowlevel.server` (stdio peer closed mid-message, recovered by the server — DX-CLI-3)

…provided no unhandled exception is attached. Unhandled crashes from those loggers (e.g. a real bug in the embedded SDK) are still surfaced.

## Sentry issues addressed

| Issue | Title | Outcome |
|---|---|---|
| [DX-CLI-4](https://deepgram.sentry.io/issues/7470528781/) | `ValueError: I/O operation on closed file.` (rich/console) | killed at source: stdio handler returns None + execute traps closed-stream writes |
| [DX-CLI-5](https://deepgram.sentry.io/issues/7470610516/) | `ValueError: I/O operation on closed file.` (base_command:124) | same |
| [DX-CLI-1](https://deepgram.sentry.io/issues/7470287684/) | `HTTPStatusError: 503 from /kapa/mcp` | dropped by `_scrub_event` (handled by MCP SDK) |
| [DX-CLI-3](https://deepgram.sentry.io/issues/7470487463/) | `Received exception from stream: 1 validation error for JSONRPCMessage` | dropped by `_scrub_event` (peer-closed noise) |
| [DX-CLI-2](https://deepgram.sentry.io/issues/7470480754/) | `AttributeError: 'Request' object has no attribute 'send'` | **not in this PR** — bug lives in the upstream `deepgram-mcp` package's `proxy.py:handle_sse`. Needs a separate fix there. |

## Companion PR

This is the client side of [deepgram/dx-api#67](https://github.com/deepgram/dx-api/pull/67), which fixed the same architectural family (handle upstream/downstream stream disconnects cleanly) on the server end.

## Test plan

- `make test` (full suite): **965 passed, 0 failed**
- `make lint`: clean
- `make format-check`: 115 files already formatted

New tests:

- `TestExecuteStreamSafety` in `packages/deepctl-core/tests/unit/test_base.py`
  - swallows `ValueError("I/O operation on closed file")`
  - swallows `BrokenPipeError`
  - **still propagates** unrelated `ValueError`s (negative invariant guard)
- `TestMcpNoiseFilter` in `packages/deepctl-telemetry/tests/unit/test_telemetry.py`
  - drops 5xx HTTPStatusError from `mcp.client.streamable_http`
  - drops message-only event from `mcp.server.lowlevel.server`
  - **keeps** unhandled exceptions even from MCP loggers
  - **keeps** events from non-MCP loggers
  - integration with `_scrub_event`: returns None for noise, still scrubs headers/cookies/user data for normal events
- Updated `test_handle_stdio_transport_returns_none` and `test_handle_api_key_from_auth_manager` to expect None for stdio (the new contract)

## Backwards compatibility

`McpCommand.handle` for stdio mode now returns `None` instead of `MCPServerResult(status="success", ...)`. Anything programmatically calling `handle()` for stdio and reading `.status` will need to treat `None` as success. In practice this is internal to `BaseCommand.execute`, which already handles `result is None`.

## Related

- Sentry: [DX-CLI-1](https://deepgram.sentry.io/issues/7470287684/), [DX-CLI-3](https://deepgram.sentry.io/issues/7470487463/), [DX-CLI-4](https://deepgram.sentry.io/issues/7470528781/), [DX-CLI-5](https://deepgram.sentry.io/issues/7470610516/)
- Server-side companion: [deepgram/dx-api#67](https://github.com/deepgram/dx-api/pull/67)