### PR TITLE
test(core): stop output-format global leaking across tests

### DIFF
--- a/packages/deepctl-core/tests/conftest.py
+++ b/packages/deepctl-core/tests/conftest.py
@@ -1,0 +1,31 @@
+"""Shared fixtures for deepctl-core tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from deepctl_core import output as _output
+
+# Snapshot the pristine output config at import time, before any test (or a
+# test that invokes the CLI) mutates it.
+_OUTPUT_DEFAULTS = dict(_output._output_config)
+
+
+@pytest.fixture(autouse=True)
+def _reset_output_config():
+    """Isolate the process-global output config per test.
+
+    ``deepctl_core.output._output_config`` is mutable module state that
+    ``setup_output`` (called by the CLI entrypoint and some tests) overwrites,
+    with nothing resetting it afterwards. That let a format set by one test leak
+    into the next — e.g. the ``output_result`` JSON tests only passed because an
+    earlier CLI-invoking test left the global on ``"json"`` (they fail in
+    isolation). Restore the pristine defaults around every test so
+    ``output_result`` — which reads this global via ``get_output_format`` — sees
+    a deterministic format regardless of ordering.
+    """
+    _output._output_config.clear()
+    _output._output_config.update(_OUTPUT_DEFAULTS)
+    yield
+    _output._output_config.clear()
+    _output._output_config.update(_OUTPUT_DEFAULTS)

--- a/packages/deepctl-core/tests/conftest.py
+++ b/packages/deepctl-core/tests/conftest.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import pytest
-
 from deepctl_core import output as _output
 
 # Snapshot the pristine output config at import time, before any test (or a

--- a/packages/deepctl-core/tests/unit/test_base.py
+++ b/packages/deepctl-core/tests/unit/test_base.py
@@ -468,11 +468,14 @@ class TestBaseCommand:
 
     @pytest.mark.unit
     @patch("deepctl_core.base_command.console")
+    @patch(
+        "deepctl_core.output._output_config",
+        {"format": "json", "quiet": False, "verbose": False, "color": True},
+    )
     def test_output_result_json_dict(self, mock_console, mock_command_class):
         """Test output_result with JSON format and dict result."""
         command = mock_command_class()
         config = Mock(spec=Config)
-        config.get.return_value = "json"  # output.format returns json
 
         result = {"key": "value", "number": 42}
         command.output_result(result, config)
@@ -484,11 +487,14 @@ class TestBaseCommand:
 
     @pytest.mark.unit
     @patch("deepctl_core.base_command.console")
+    @patch(
+        "deepctl_core.output._output_config",
+        {"format": "json", "quiet": False, "verbose": False, "color": True},
+    )
     def test_output_result_json_list(self, mock_console, mock_command_class):
         """Test output_result with JSON format and list result."""
         command = mock_command_class()
         config = Mock(spec=Config)
-        config.get.return_value = "json"
 
         result = [{"id": 1}, {"id": 2}]
         command.output_result(result, config)
@@ -499,11 +505,14 @@ class TestBaseCommand:
 
     @pytest.mark.unit
     @patch("deepctl_core.base_command.console")
+    @patch(
+        "deepctl_core.output._output_config",
+        {"format": "json", "quiet": False, "verbose": False, "color": True},
+    )
     def test_output_result_json_string(self, mock_console, mock_command_class):
         """Test output_result with JSON format and string result."""
         command = mock_command_class()
         config = Mock(spec=Config)
-        config.get.return_value = "json"
 
         result = "simple string"
         command.output_result(result, config)
@@ -517,6 +526,10 @@ class TestBaseCommand:
         assert json.loads(actual_output) == expected_data
 
     @pytest.mark.unit
+    @patch(
+        "deepctl_core.output._output_config",
+        {"format": "json", "quiet": False, "verbose": False, "color": True},
+    )
     def test_output_result_pydantic_model(self, mock_command_class):
         """Test output_result with Pydantic model."""
         from pydantic import BaseModel
@@ -527,7 +540,6 @@ class TestBaseCommand:
 
         command = mock_command_class()
         config = Mock(spec=Config)
-        config.get.return_value = "json"
 
         result = TestModel(name="test", value=123)
 
@@ -538,6 +550,10 @@ class TestBaseCommand:
             mock_output_json.assert_called_once_with({"name": "test", "value": 123})
 
     @pytest.mark.unit
+    @patch(
+        "deepctl_core.output._output_config",
+        {"format": "json", "quiet": False, "verbose": False, "color": True},
+    )
     def test_output_result_list_of_pydantic_models(self, mock_command_class):
         """Test output_result with list of Pydantic models."""
         from pydantic import BaseModel
@@ -548,7 +564,6 @@ class TestBaseCommand:
 
         command = mock_command_class()
         config = Mock(spec=Config)
-        config.get.return_value = "json"
 
         result = [
             TestModel(name="test1", value=1),
@@ -1049,27 +1064,30 @@ class TestConfirmPromptGating:
     @pytest.mark.unit
     def test_confirm_calls_click_when_guided_and_not_agentic(self, command):
         command._guided = True
-        with patch("deepctl_core.base_command._agentic", False), patch(
-            "deepctl_core.base_command.click.confirm", return_value=True
-        ) as mock:
+        with (
+            patch("deepctl_core.base_command._agentic", False),
+            patch("deepctl_core.base_command.click.confirm", return_value=True) as mock,
+        ):
             assert command.confirm("OK?", default=False) is True
         mock.assert_called_once()
 
     @pytest.mark.unit
     def test_confirm_returns_default_when_not_guided(self, command):
         command._guided = False
-        with patch("deepctl_core.base_command._agentic", False), patch(
-            "deepctl_core.base_command.click.confirm"
-        ) as mock:
+        with (
+            patch("deepctl_core.base_command._agentic", False),
+            patch("deepctl_core.base_command.click.confirm") as mock,
+        ):
             assert command.confirm("OK?", default=False) is False
         mock.assert_not_called()
 
     @pytest.mark.unit
     def test_confirm_returns_default_when_agentic(self, command):
         command._guided = True
-        with patch("deepctl_core.base_command._agentic", True), patch(
-            "deepctl_core.base_command.click.confirm"
-        ) as mock:
+        with (
+            patch("deepctl_core.base_command._agentic", True),
+            patch("deepctl_core.base_command.click.confirm") as mock,
+        ):
             assert command.confirm("OK?", default=True) is True
         mock.assert_not_called()
 
@@ -1077,27 +1095,32 @@ class TestConfirmPromptGating:
     def test_confirm_returns_default_when_not_ci_friendly(self, command):
         command.ci_friendly = False
         command._guided = True
-        with patch("deepctl_core.base_command._agentic", False), patch(
-            "deepctl_core.base_command.click.confirm"
-        ) as mock:
+        with (
+            patch("deepctl_core.base_command._agentic", False),
+            patch("deepctl_core.base_command.click.confirm") as mock,
+        ):
             assert command.confirm("OK?", default=False) is False
         mock.assert_not_called()
 
     @pytest.mark.unit
     def test_prompt_calls_click_when_guided(self, command):
         command._guided = True
-        with patch("deepctl_core.base_command._agentic", False), patch(
-            "deepctl_core.base_command.click.prompt", return_value="user-input"
-        ) as mock:
+        with (
+            patch("deepctl_core.base_command._agentic", False),
+            patch(
+                "deepctl_core.base_command.click.prompt", return_value="user-input"
+            ) as mock,
+        ):
             assert command.prompt("Name?", default="alice") == "user-input"
         mock.assert_called_once()
 
     @pytest.mark.unit
     def test_prompt_returns_default_when_not_guided(self, command):
         command._guided = False
-        with patch("deepctl_core.base_command._agentic", False), patch(
-            "deepctl_core.base_command.click.prompt"
-        ) as mock:
+        with (
+            patch("deepctl_core.base_command._agentic", False),
+            patch("deepctl_core.base_command.click.prompt") as mock,
+        ):
             assert command.prompt("Name?", default="alice") == "alice"
         mock.assert_not_called()
 
@@ -1105,9 +1128,12 @@ class TestConfirmPromptGating:
     def test_prompt_with_no_default_still_prompts_when_not_guided(self, command):
         # Pre-existing safety: prompt() only short-circuits when default is not None
         command._guided = False
-        with patch("deepctl_core.base_command._agentic", False), patch(
-            "deepctl_core.base_command.click.prompt", return_value="typed"
-        ) as mock:
+        with (
+            patch("deepctl_core.base_command._agentic", False),
+            patch(
+                "deepctl_core.base_command.click.prompt", return_value="typed"
+            ) as mock,
+        ):
             assert command.prompt("Name?", default=None) == "typed"
         mock.assert_called_once()
 
@@ -1161,9 +1187,7 @@ class TestIsGuided:
 
     @pytest.mark.unit
     def test_env_var_breaks_guided(self, command):
-        ctx = self._ctx_with_sources(
-            {"foo": "DEFAULT", "bar": "ENVIRONMENT"}
-        )
+        ctx = self._ctx_with_sources({"foo": "DEFAULT", "bar": "ENVIRONMENT"})
         with patch("deepctl_core.base_command._agentic", False):
             assert command.is_guided(ctx) is False
 

--- a/packages/deepctl-core/tests/unit/test_base.py
+++ b/packages/deepctl-core/tests/unit/test_base.py
@@ -8,6 +8,17 @@ import pytest
 from click.testing import CliRunner
 from deepctl_core import AuthManager, BaseCommand, Config, DeepgramClient
 
+# Mirrors the full key set of deepctl_core.output._output_config so a patched
+# stand-in can't drift from the real global. Spread with a format override,
+# e.g. {**_OUTPUT_CONFIG_DEFAULTS, "format": "json"}, at each patch site.
+_OUTPUT_CONFIG_DEFAULTS = {
+    "format": "default",
+    "quiet": False,
+    "verbose": False,
+    "color": True,
+    "agentic": False,
+}
+
 
 class TestBaseCommand:
     """Test suite for BaseCommand class."""
@@ -470,7 +481,7 @@ class TestBaseCommand:
     @patch("deepctl_core.base_command.console")
     @patch(
         "deepctl_core.output._output_config",
-        {"format": "json", "quiet": False, "verbose": False, "color": True},
+        {**_OUTPUT_CONFIG_DEFAULTS, "format": "json"},
     )
     def test_output_result_json_dict(self, mock_console, mock_command_class):
         """Test output_result with JSON format and dict result."""
@@ -489,7 +500,7 @@ class TestBaseCommand:
     @patch("deepctl_core.base_command.console")
     @patch(
         "deepctl_core.output._output_config",
-        {"format": "json", "quiet": False, "verbose": False, "color": True},
+        {**_OUTPUT_CONFIG_DEFAULTS, "format": "json"},
     )
     def test_output_result_json_list(self, mock_console, mock_command_class):
         """Test output_result with JSON format and list result."""
@@ -507,7 +518,7 @@ class TestBaseCommand:
     @patch("deepctl_core.base_command.console")
     @patch(
         "deepctl_core.output._output_config",
-        {"format": "json", "quiet": False, "verbose": False, "color": True},
+        {**_OUTPUT_CONFIG_DEFAULTS, "format": "json"},
     )
     def test_output_result_json_string(self, mock_console, mock_command_class):
         """Test output_result with JSON format and string result."""
@@ -528,7 +539,7 @@ class TestBaseCommand:
     @pytest.mark.unit
     @patch(
         "deepctl_core.output._output_config",
-        {"format": "json", "quiet": False, "verbose": False, "color": True},
+        {**_OUTPUT_CONFIG_DEFAULTS, "format": "json"},
     )
     def test_output_result_pydantic_model(self, mock_command_class):
         """Test output_result with Pydantic model."""
@@ -552,7 +563,7 @@ class TestBaseCommand:
     @pytest.mark.unit
     @patch(
         "deepctl_core.output._output_config",
-        {"format": "json", "quiet": False, "verbose": False, "color": True},
+        {**_OUTPUT_CONFIG_DEFAULTS, "format": "json"},
     )
     def test_output_result_list_of_pydantic_models(self, mock_command_class):
         """Test output_result with list of Pydantic models."""
@@ -582,7 +593,7 @@ class TestBaseCommand:
     @patch("deepctl_core.base_command.console")
     @patch(
         "deepctl_core.output._output_config",
-        {"format": "yaml", "quiet": False, "verbose": False, "color": True},
+        {**_OUTPUT_CONFIG_DEFAULTS, "format": "yaml"},
     )
     def test_output_result_yaml(self, mock_console, mock_command_class):
         """Test output_result with YAML format."""
@@ -602,7 +613,7 @@ class TestBaseCommand:
     @patch("deepctl_core.base_command.console")
     @patch(
         "deepctl_core.output._output_config",
-        {"format": "table", "quiet": False, "verbose": False, "color": True},
+        {**_OUTPUT_CONFIG_DEFAULTS, "format": "table"},
     )
     def test_output_result_table_list_of_dicts(self, mock_console, mock_command_class):
         """Test output_result with table format and list of dicts."""
@@ -621,7 +632,7 @@ class TestBaseCommand:
     @patch("deepctl_core.base_command.console")
     @patch(
         "deepctl_core.output._output_config",
-        {"format": "table", "quiet": False, "verbose": False, "color": True},
+        {**_OUTPUT_CONFIG_DEFAULTS, "format": "table"},
     )
     def test_output_result_table_dict(self, mock_console, mock_command_class):
         """Test output_result with table format and dict."""
@@ -638,7 +649,7 @@ class TestBaseCommand:
     @patch("deepctl_core.base_command.console")
     @patch(
         "deepctl_core.output._output_config",
-        {"format": "csv", "quiet": False, "verbose": False, "color": True},
+        {**_OUTPUT_CONFIG_DEFAULTS, "format": "csv"},
     )
     def test_output_result_csv_list_of_dicts(self, mock_console, mock_command_class):
         """Test output_result with CSV format and list of dicts."""
@@ -659,7 +670,7 @@ class TestBaseCommand:
     @patch("deepctl_core.base_command.console")
     @patch(
         "deepctl_core.output._output_config",
-        {"format": "csv", "quiet": False, "verbose": False, "color": True},
+        {**_OUTPUT_CONFIG_DEFAULTS, "format": "csv"},
     )
     def test_output_result_csv_dict(self, mock_console, mock_command_class):
         """Test output_result with CSV format and dict."""
@@ -680,7 +691,7 @@ class TestBaseCommand:
     @patch("deepctl_core.base_command.console")
     @patch(
         "deepctl_core.output._output_config",
-        {"format": "unknown", "quiet": False, "verbose": False, "color": True},
+        {**_OUTPUT_CONFIG_DEFAULTS, "format": "unknown"},
     )
     def test_output_result_unknown_format(self, mock_console, mock_command_class):
         """Test output_result with unknown format falls back to JSON."""


### PR DESCRIPTION
## Problem

`BaseCommand.output_result` reads the output format from the process-global `deepctl_core.output._output_config` (via `get_output_format()`), **not** from `config.get()`. But five `TestBaseCommand.test_output_result_*` JSON tests only stubbed `config.get.return_value = "json"` — a value the code never reads.

As a result those tests depended on an earlier CLI-invoking test having left the global on `"json"` (the CLI entrypoint `src/deepctl/main.py` calls `setup_output()`, which mutates the global and nothing resets it). They **pass in the full suite by collection-order luck and fail in isolation**:

```
# on main
$ pytest packages/deepctl-core/tests/unit/test_base.py
5 failed, 83 passed
```

In isolation the format is its default `"default"`, so `output_result` returns early and `_output_json` / `print_json` is never called → the assertions fail.

## Fix (both halves)

1. **Tests set what the code reads.** The 5 JSON tests now `@patch("deepctl_core.output._output_config", {...})` — the same pattern the yaml/table/csv tests already use — instead of the no-op `config.get` stub. All 11 format patch sites now spread a shared `_OUTPUT_CONFIG_DEFAULTS` constant (`{**_OUTPUT_CONFIG_DEFAULTS, "format": "json"}`) that mirrors the real global's full key set, so the stand-in can't drift from `_output_config` (previously the dicts omitted `agentic`).
2. **Stop the leak.** New autouse fixture in `packages/deepctl-core/tests/conftest.py` restores the pristine `_output_config` around every core test, so a format set by one test can no longer bleed into the next.

Half 1 makes the tests correct on their own; half 2 keeps the latent ordering bug from silently returning.

## Verification

```
# in isolation (was 5 failed)
$ pytest packages/deepctl-core/tests/unit/test_base.py   → 88 passed
# whole core unit dir (was 5 failed)
$ pytest packages/deepctl-core/tests/unit                → 354 passed
# full suite
$ pytest                                                 → 976 passed
```
ruff / format clean (only test files touched). No `src/` changes.

## Note on the diff

Includes ~90 lines of `ruff format` reflow in `TestConfirmPromptGating` / `TestIsGuided` (the `with patch(A), patch(B):` blocks became parenthesized `with ( … ):` form, plus one line-wrap). All behavior-neutral formatter output, no logic change — called out here so it doesn't read as unexplained scope.

## Scope

Pre-existing core test hygiene — independent of #92. Reset fixture is intentionally core-scoped to limit blast radius; a root-level version (covering cross-package leakage) can follow if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
