### PR TITLE
fix(release): bump pypi-publish action to v1.14.2 for Metadata-Version 2.5

### DIFF
--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -52,7 +52,7 @@ jobs:
         run: make verify-packages
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
           packages-dir: dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
           packages-dir: dist/


### PR DESCRIPTION
## What broke

The `0.2.27` release tagged successfully, but **`Publish to PyPI` failed — nothing reached PyPI**. The latest installable version is still `0.2.26` (`pypi.org/pypi/deepctl/0.2.27/json` → 404).

The pinned `pypa/gh-action-pypi-publish` image runs a `twine check` before uploading, and it rejected two wheels:

```
Checking dist/deepctl_cmd_plugin-0.1.12-py3-none-any.whl:
  ERROR InvalidDistribution: Invalid distribution metadata:
  '2.5' is not a valid metadata version
```

### Root cause

- 2 of the 31 packages (`deepctl-cmd-plugin`, `deepctl-cmd-skills`) build with **hatchling**, which now emits `Metadata-Version: 2.5`. The other 29 use setuptools and emit `2.4`.
- The **`pkginfo` bundled inside the old pinned action image predates Metadata 2.5**, so its `twine check` errors out — aborting the step *before any upload happened*.
- `make verify-packages` passed in the `Build` job because CI's own twine is current. Only the action's bundled copy was stale.
- It surfaced now (and not in `0.2.26`) because **hatchling was upgraded in the lockfile** after `0.2.26` shipped.

## The fix

Bump the action pin `ed0c539` → `dc37677` (**v1.14.2**), whose twine understands Metadata 2.5.

**Verified locally** against the `v0.2.27` tree: all **62 artifacts** (31 wheels + 31 sdists), including both `Metadata-Version: 2.5` wheels, `PASSED` `twine check` on twine 7.0.0.

## Why this rolls forward to 0.2.28 instead of republishing 0.2.27

`v0.2.27` is tagged with a GitHub Release but has no PyPI artifact, and it **cannot be re-published**: `release.yml`'s build/test/publish jobs are gated on release-please's `release_created`, which is only true on the run that *cuts* a release. Re-running the failed run would also reuse the old (broken) pin.

So merging this cuts **0.2.28**, which ships **identical code to 0.2.27 plus this pipeline fix**. The follow-up release PR will carry the full 0.2.27 feature set (Flux TTS default, Flux controls, listen redact/numerals, SDK 7.7.0, MCP pipe-safety) through to PyPI.

`v0.2.27` stays as a tag/GitHub Release with no PyPI artifact — worth a note on that release so nobody hunts for `pip install deepctl==0.2.27`.

## Follow-ups (not in this PR)

- **Attestations warning:** the publish step warns that `attestations: true` is ignored because an explicit password is set. Harmless, but silenceable with `attestations: false` — or resolved properly by moving to **Trusted Publishing** (the action already prints the enablement links).
- **Changelog noise:** `#92` was a scope-less squashed `feat:` whose README/`pyproject` pin edits rippled into `deepctl-cmd-login`/`projects`/`usage`, giving those packages a "Flux TTS controls" feature entry they didn't gain. Per-package commit scoping (or a path filter) would prevent that.
